### PR TITLE
Extract common base class for ICryptoOrderBook implementations

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,7 @@
 	<!-- Project defaults -->
 
 	<PropertyGroup>
+		<LangVersion>latest</LangVersion>
 		<Version>2.7.1</Version>
 	</PropertyGroup>
 

--- a/src/Crypto.Websocket.Extensions.Core/Models/CryptoQuotes.cs
+++ b/src/Crypto.Websocket.Extensions.Core/Models/CryptoQuotes.cs
@@ -23,27 +23,27 @@ namespace Crypto.Websocket.Extensions.Core.Models
         /// <summary>
         /// Top level bid price
         /// </summary>
-        public double Bid { get; }
+        public double Bid { get; internal set; }
 
         /// <summary>
         /// Top level ask price
         /// </summary>
-        public double Ask { get; }
+        public double Ask { get; internal set; }
 
         /// <summary>
         /// Current mid price
         /// </summary>
-        public double Mid { get; }
+        public double Mid { get; internal set; }
 
         /// <summary>
         /// Top level bid amount
         /// </summary>
-        public double BidAmount { get; }
+        public double BidAmount { get; internal set; }
 
         /// <summary>
         /// Top level ask amount
         /// </summary>
-        public double AskAmount { get; }
+        public double AskAmount { get; internal set; }
 
         /// <summary>
         /// Returns true if quotes are in valid state

--- a/src/Crypto.Websocket.Extensions.Core/OrderBooks/CryptoOrderBook.cs
+++ b/src/Crypto.Websocket.Extensions.Core/OrderBooks/CryptoOrderBook.cs
@@ -21,40 +21,13 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
     /// Process order book data from one source and one target pair.
     /// Only first levels are computed in advance, allocates more memory than CryptoOrderBookL2 counterpart. 
     /// </summary>
-    [DebuggerDisplay("CryptoOrderBook [{TargetPair} {TargetType}] bid: {BidPrice} ({_bidLevels.Count}) ask: {AskPrice} ({_askLevels.Count})")]
-    public class CryptoOrderBook : ICryptoOrderBook
+    [DebuggerDisplay("CryptoOrderBook [{TargetPair} {TargetType}] bid: {BidPrice} ({BidLevelsInternal.Count}) ask: {AskPrice} ({AskLevelsInternal.Count})")]
+    public class CryptoOrderBook : CryptoOrderBookBase<OrderedDictionary>
     {
-        private readonly object _locker = new object();
-
-        private readonly IOrderBookSource _source;
-
-        private readonly Subject<OrderBookChangeInfo> _bidAskUpdated = new Subject<OrderBookChangeInfo>();
-        private readonly Subject<OrderBookChangeInfo> _topLevelUpdated = new Subject<OrderBookChangeInfo>();
-        private readonly Subject<OrderBookChangeInfo> _orderBookUpdated = new Subject<OrderBookChangeInfo>();
-
-        private readonly SortedList<double, OrderedDictionary> _bidLevels = new SortedList<double, OrderedDictionary>(new DescendingComparer());
-        private readonly SortedList<double, OrderedDictionary> _askLevels = new SortedList<double, OrderedDictionary>();
-
-        private readonly OrderBookLevelsOrderPerPrice _bidLevelOrdering = new OrderBookLevelsOrderPerPrice(200);
-        private readonly OrderBookLevelsOrderPerPrice _askLevelOrdering = new OrderBookLevelsOrderPerPrice(200);
-
-        private readonly OrderBookLevelsById _allBidLevels = new OrderBookLevelsById(500);
-        private readonly OrderBookLevelsById _allAskLevels = new OrderBookLevelsById(500);
-
-        private bool _isSnapshotLoaded;
-        private Timer? _snapshotReloadTimer;
-        private TimeSpan _snapshotReloadTimeout = TimeSpan.FromMinutes(1);
-        private bool _snapshotReloadEnabled;
-
-        private Timer? _validityCheckTimer;
-        private TimeSpan _validityCheckTimeout = TimeSpan.FromSeconds(5);
-        private bool _validityCheckEnabled = true;
-        private int _validityCheckCounter;
+        private readonly OrderBookLevelsOrderPerPrice _bidLevelOrdering = new(200);
+        private readonly OrderBookLevelsOrderPerPrice _askLevelOrdering = new(200);
 
         private readonly int _priceLevelInitialCapacity = 2;
-
-        private IDisposable? _subscriptionDiff;
-        private IDisposable? _subscriptionSnapshot;
 
         /// <summary>
         /// Cryptocurrency order book.
@@ -63,491 +36,80 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
         /// <param name="targetPair">Select target pair</param>
         /// <param name="source">Provide order book data source</param>
         /// <param name="targetType">Select target precision (default: All - accepts every type of data)</param>
-        public CryptoOrderBook(string targetPair, IOrderBookSource source, CryptoOrderBookType targetType = CryptoOrderBookType.All)
+        public CryptoOrderBook(string targetPair, IOrderBookSource source, CryptoOrderBookType targetType = CryptoOrderBookType.All) : base(targetPair, source)
         {
-            CryptoValidations.ValidateInput(targetPair, nameof(targetPair));
-            CryptoValidations.ValidateInput(source, nameof(source));
-
-            TargetPairOriginal = targetPair;
-            TargetPair = CryptoPairsHelper.Clean(targetPair);
-            _source = source;
             TargetType = targetType;
 
-            if (targetType == CryptoOrderBookType.L1 || targetType == CryptoOrderBookType.L2)
+            if (targetType is CryptoOrderBookType.L1 or CryptoOrderBookType.L2)
             {
                 // save memory, only one order at price level
                 _priceLevelInitialCapacity = 1;
             }
-            else if (targetType == CryptoOrderBookType.L3)
+            else if (targetType is CryptoOrderBookType.L3)
             {
                 // better performance, could be multiple orders at price level
                 _priceLevelInitialCapacity = 5;
             }
 
-            Subscribe();
-            RestartAutoSnapshotReloading();
-            RestartValidityChecking();
+            Initialize();
         }
-
-        /// <summary>
-        /// Dispose background processing
-        /// </summary>
-        public void Dispose()
-        {
-            DeactivateAutoSnapshotReloading();
-            DeactivateValidityChecking();
-            _source.Dispose();
-            _subscriptionDiff?.Dispose();
-            _subscriptionSnapshot?.Dispose();
-        }
-
-        /// <summary>
-        /// Origin exchange name
-        /// </summary>
-        public string ExchangeName => _source.ExchangeName;
-
-        /// <summary>
-        /// Target pair for this order book data
-        /// </summary>
-        public string TargetPair { get; }
-
-        /// <summary>
-        /// Originally provided target pair for this order book data
-        /// </summary>
-        public string TargetPairOriginal { get; }
-
-        /// <summary>
-        /// Order book type, which precision it supports
-        /// </summary>
-        public CryptoOrderBookType TargetType { get; }
-
-        /// <summary>
-        /// Time interval for auto snapshot reloading.
-        /// Default 1 min. 
-        /// </summary>
-        public TimeSpan SnapshotReloadTimeout
-        {
-            get => _snapshotReloadTimeout;
-            set
-            {
-                _snapshotReloadTimeout = value;
-                RestartAutoSnapshotReloading();
-            }
-        }
-
-        /// <summary>
-        /// Whenever auto snapshot reloading feature is enabled.
-        /// Disabled by default
-        /// </summary>
-        public bool SnapshotReloadEnabled
-        {
-            get => _snapshotReloadEnabled;
-            set
-            {
-                _snapshotReloadEnabled = value;
-                RestartAutoSnapshotReloading();
-            }
-        }
-
-        /// <summary>
-        /// Time interval for validity checking.
-        /// It forces snapshot reloading whenever invalid state. 
-        /// Default 5 sec. 
-        /// </summary>
-        public TimeSpan ValidityCheckTimeout
-        {
-            get => _validityCheckTimeout;
-            set
-            {
-                _validityCheckTimeout = value;
-                RestartValidityChecking();
-            }
-        }
-
-        /// <summary>
-        /// How many times it should check validity before processing snapshot reload.
-        /// Default 6 times (which is 6 * 5sec = 30sec).
-        /// </summary>
-        public int ValidityCheckLimit { get; set; } = 6;
-
-        /// <summary>
-        /// Whenever validity checking feature is enabled.
-        /// It forces snapshot reloading whenever invalid state. 
-        /// Enabled by default
-        /// </summary>
-        public bool ValidityCheckEnabled
-        {
-            get => _validityCheckEnabled;
-            set
-            {
-                _validityCheckEnabled = value;
-                RestartValidityChecking();
-            }
-        }
-
-        /// <summary>
-        /// Provide more info (on every change) whenever enabled. 
-        /// Disabled by default
-        /// </summary>
-        public bool DebugEnabled { get; set; } = false;
-
-        /// <summary>
-        /// Logs more info (state, performance) whenever enabled. 
-        /// Disabled by default
-        /// </summary>
-        public bool DebugLogEnabled { get; set; } = false;
-
-        /// <summary>
-        /// Whenever snapshot was already handled
-        /// </summary>
-        public bool IsSnapshotLoaded => _isSnapshotLoaded;
-
-        /// <summary>
-        /// All diffs/deltas that come before snapshot will be ignored (default: true)
-        /// </summary>
-        public bool IgnoreDiffsBeforeSnapshot { get; set; } = true;
-
-        /// <summary>
-        /// Compute index (position) per every updated level, performance is slightly reduced (default: false) 
-        /// </summary>
-        public bool IsIndexComputationEnabled { get; set; }
-
-        /// <summary>
-        /// Streams data when top level bid or ask price was updated
-        /// </summary>
-        public IObservable<IOrderBookChangeInfo> BidAskUpdatedStream => _bidAskUpdated.AsObservable();
-
-        /// <summary>
-        /// Streams data when top level bid or ask price or amount was updated
-        /// </summary>
-        public IObservable<IOrderBookChangeInfo> TopLevelUpdatedStream => _topLevelUpdated.AsObservable();
-
-        /// <summary>
-        /// Streams data on every order book change (price or amount at any level)
-        /// </summary>
-        public IObservable<IOrderBookChangeInfo> OrderBookUpdatedStream => _orderBookUpdated.AsObservable();
-
-        /// <summary>
-        /// Current bid side of the order book (ordered from higher to lower price)
-        /// </summary>
-        public OrderBookLevel[] BidLevels => ComputeBidLevels();
 
         /// <summary>
         /// Current bid side of the order book grouped by price (ordered from higher to lower price)
         /// </summary>
-        public IReadOnlyDictionary<double, OrderBookLevel[]> BidLevelsPerPrice => ComputeLevelsPerPrice(_bidLevels);
-
-        /// <summary>
-        /// Current ask side of the order book (ordered from lower to higher price)
-        /// </summary>
-        public OrderBookLevel[] AskLevels => ComputeAskLevels();
+        public IReadOnlyDictionary<double, OrderBookLevel[]> BidLevelsPerPrice => ComputeLevelsPerPrice(BidLevelsInternal);
 
         /// <summary>
         /// Current ask side of the order book grouped by price (ordered from lower to higher price)
         /// </summary>
-        public IReadOnlyDictionary<double, OrderBookLevel[]> AskLevelsPerPrice => ComputeLevelsPerPrice(_askLevels);
+        public IReadOnlyDictionary<double, OrderBookLevel[]> AskLevelsPerPrice => ComputeLevelsPerPrice(AskLevelsInternal);
 
-        /// <summary>
-        /// All current levels together
-        /// </summary>
-        public OrderBookLevel[] Levels => ComputeAllLevels();
-
-        /// <summary>
-        /// Current top level bid price
-        /// </summary>
-        public double BidPrice { get; private set; }
-
-        /// <summary>
-        /// Current top level ask price
-        /// </summary>
-        public double AskPrice { get; private set; }
-
-        /// <summary>
-        /// Current mid price
-        /// </summary>
-        public double MidPrice => (AskPrice + BidPrice) / 2;
-
-        /// <summary>
-        /// Current top level bid amount
-        /// </summary>
-        public double BidAmount { get; private set; }
-
-        /// <summary>
-        /// Current top level ask price
-        /// </summary>
-        public double AskAmount { get; private set; }
-
-        /// <summary>
-        /// Returns true if order book is in valid state
-        /// </summary>
-        public bool IsValid()
+        /// <inheritdoc />
+        public override OrderBookLevel FindBidLevelByPrice(double price)
         {
-            var isPriceValid = BidPrice <= AskPrice;
-            return isPriceValid && _source.IsValid();
-        }
-
-
-        /// <summary>
-        /// Find bid level for provided price (returns null in case of missing)
-        /// </summary>
-        public OrderBookLevel? FindBidLevelByPrice(double price)
-        {
-            lock (_locker)
+            lock (Locker)
             {
-                if (_bidLevels.TryGetValue(price, out OrderedDictionary? group))
-                    return group.Values.OfType<OrderBookLevel>().FirstOrDefault();
-                return null;
+                return BidLevelsInternal.TryGetValue(price, out var group)
+                    ? group.Values.OfType<OrderBookLevel>().FirstOrDefault()
+                    : null;
             }
         }
 
-        /// <summary>
-        /// Find all bid levels for provided price (returns empty when not found)
-        /// </summary>
-        public OrderBookLevel[] FindBidLevelsByPrice(double price)
+        /// <inheritdoc />
+        public override OrderBookLevel[] FindBidLevelsByPrice(double price)
         {
-            lock (_locker)
+            lock (Locker)
             {
-                if (_bidLevels.TryGetValue(price, out OrderedDictionary? group))
-                    return group.Values.OfType<OrderBookLevel>().ToArray();
-                return Array.Empty<OrderBookLevel>();
+                return BidLevelsInternal.TryGetValue(price, out var group)
+                    ? group.Values.OfType<OrderBookLevel>().ToArray()
+                    : Array.Empty<OrderBookLevel>();
             }
         }
 
-
-        /// <summary>
-        /// Find ask level for provided price (returns null in case of missing)
-        /// </summary>
-        public OrderBookLevel? FindAskLevelByPrice(double price)
+        /// <inheritdoc />
+        public override OrderBookLevel FindAskLevelByPrice(double price)
         {
-            lock (_locker)
+            lock (Locker)
             {
-                if (_askLevels.TryGetValue(price, out OrderedDictionary? group))
-                    return group.Values.OfType<OrderBookLevel>().FirstOrDefault();
-                return null;
+                return AskLevelsInternal.TryGetValue(price, out var group)
+                    ? group.Values.OfType<OrderBookLevel>().FirstOrDefault()
+                    : null;
             }
         }
 
-        /// <summary>
-        /// Find all ask levels for provided price (returns empty when not found)
-        /// </summary>
-        public OrderBookLevel[] FindAskLevelsByPrice(double price)
+        /// <inheritdoc />
+        public override OrderBookLevel[] FindAskLevelsByPrice(double price)
         {
-            lock (_locker)
+            lock (Locker)
             {
-                if (_askLevels.TryGetValue(price, out OrderedDictionary? group))
-                    return group.Values.OfType<OrderBookLevel>().ToArray();
-                return Array.Empty<OrderBookLevel>();
+                return AskLevelsInternal.TryGetValue(price, out var group)
+                    ? group.Values.OfType<OrderBookLevel>().ToArray()
+                    : Array.Empty<OrderBookLevel>();
             }
         }
 
-        /// <summary>
-        /// Find bid level by provided identification (returns null in case of not found)
-        /// </summary>
-        public OrderBookLevel? FindBidLevelById(string id)
-        {
-            return FindLevelById(id, CryptoOrderSide.Bid);
-        }
-
-        /// <summary>
-        /// Find ask level by provided identification (returns null in case of not found)
-        /// </summary>
-        public OrderBookLevel? FindAskLevelById(string id)
-        {
-            return FindLevelById(id, CryptoOrderSide.Ask);
-        }
-
-        /// <summary>
-        /// Find level by provided identification (returns null in case of not found).
-        /// You need to specify side.
-        /// </summary>
-        public OrderBookLevel? FindLevelById(string id, CryptoOrderSide side)
-        {
-            if (side == CryptoOrderSide.Undefined)
-                return null;
-            var collection = GetAllCollection(side);
-            return collection.GetValueOrDefault(id);
-        }
-
-        private void Subscribe()
-        {
-            _subscriptionSnapshot = _source
-                .OrderBookSnapshotStream
-                .Subscribe(HandleSnapshotSynchronized);
-
-            _subscriptionDiff = _source
-                .OrderBookStream
-                .Subscribe(HandleDiffSynchronized);
-        }
-
-        private void HandleSnapshotSynchronized(OrderBookLevelBulk bulk)
-        {
-            if (bulk == null || !IsCorrectType(bulk.OrderBookType))
-                return;
-
-            var levels = bulk.Levels;
-            var levelsForThis = levels
-                .Where(x => TargetPair.Equals(x.Pair))
-                .ToList();
-            if (!levelsForThis.Any())
-            {
-                // snapshot for different pair, ignore
-                return;
-            }
-
-            double oldBid;
-            double oldAsk;
-            double oldBidAmount;
-            double oldAskAmount;
-            OrderBookChangeInfo change;
-
-            lock (_locker)
-            {
-                oldBid = BidPrice;
-                oldAsk = AskPrice;
-                oldBidAmount = BidAmount;
-                oldAskAmount = AskAmount;
-                HandleSnapshot(levelsForThis);
-
-                change = CreateBookChangeNotification(
-                    levelsForThis,
-                    new[] { bulk },
-                    true
-                );
-            }
-
-            _orderBookUpdated.OnNext(change);
-            NotifyIfTopLevelChanged(oldBid, oldAsk, oldBidAmount, oldAskAmount, change);
-            NotifyIfBidAskChanged(oldBid, oldAsk, change);
-        }
-
-        private void HandleDiffSynchronized(OrderBookLevelBulk[] bulks)
-        {
-            var sw = DebugEnabled ? Stopwatch.StartNew() : null;
-
-            var forThis = bulks
-                .Where(x => x != null)
-                .Where(x => IsCorrectType(x.OrderBookType))
-                //.Where(x => x.Levels.Any(y => TargetPair.Equals(y.Pair)))
-                .ToArray();
-            if (!forThis.Any())
-            {
-                // data for different pair, ignore
-                return;
-            }
-
-            double oldBid;
-            double oldAsk;
-            double oldBidAmount;
-            double oldAskAmount;
-            var allLevels = new List<OrderBookLevel>();
-            OrderBookChangeInfo change;
-
-            lock (_locker)
-            {
-                oldBid = BidPrice;
-                oldAsk = AskPrice;
-                oldBidAmount = BidAmount;
-                oldAskAmount = AskAmount;
-
-                foreach (var bulk in forThis)
-                {
-                    var levelsForThis = bulk.Levels
-                        .Where(x => TargetPair.Equals(x.Pair))
-                        .ToArray();
-                    allLevels.AddRange(levelsForThis);
-                    HandleDiff(bulk, levelsForThis);
-                }
-
-                RecomputeAfterChangeAndSetIndexes(allLevels);
-
-                change = CreateBookChangeNotification(
-                    allLevels,
-                    forThis,
-                    false
-                );
-            }
-
-            if (allLevels.Any())
-                _orderBookUpdated.OnNext(change);
-            NotifyIfBidAskChanged(oldBid, oldAsk, change);
-            NotifyIfTopLevelChanged(oldBid, oldAsk, oldBidAmount, oldAskAmount, change);
-
-            if (sw != null)
-            {
-                var levels = forThis.SelectMany(x => x.Levels).Count();
-                LogDebug($"Diff ({forThis.Length} bulks, {levels} levels) processing took {sw.ElapsedMilliseconds} ms, {sw.ElapsedTicks} ticks");
-            }
-        }
-
-        private void HandleSnapshot(List<OrderBookLevel> levels)
-        {
-            _bidLevels.Clear();
-            _bidLevelOrdering.Clear();
-            _askLevels.Clear();
-            _askLevelOrdering.Clear();
-            _allBidLevels.Clear();
-            _allAskLevels.Clear();
-
-            LogDebug($"Handling snapshot: {levels.Count} levels");
-            foreach (var level in levels)
-            {
-                var price = level.Price;
-                if (price == null || price < 0)
-                {
-                    LogAlways($"Received snapshot level with weird price, ignoring. " +
-                              $"[{level.Side}] Id: {level.Id}, price: {level.Price}, amount: {level.Amount}");
-                    continue;
-                }
-
-                level.AmountDifference = level.Amount ?? 0;
-                level.CountDifference = level.Count ?? 0;
-
-                if (level.Side == CryptoOrderSide.Bid)
-                {
-                    InsertLevelIntoPriceGroup(level, _bidLevels, _bidLevelOrdering);
-                    _allBidLevels[level.Id] = level;
-                }
-
-
-                if (level.Side == CryptoOrderSide.Ask)
-                {
-                    InsertLevelIntoPriceGroup(level, _askLevels, _askLevelOrdering);
-                    _allAskLevels[level.Id] = level;
-                }
-            }
-
-            RecomputeAfterChangeAndSetIndexes(levels);
-
-            _isSnapshotLoaded = true;
-        }
-
-        private void HandleDiff(OrderBookLevelBulk bulk, OrderBookLevel[] correctLevels)
-        {
-            if (IgnoreDiffsBeforeSnapshot && !_isSnapshotLoaded)
-            {
-                LogDebug($"Snapshot not loaded yet, ignoring bulk: {bulk.Action} {correctLevels.Length} levels");
-                // snapshot is not loaded yet, ignore data
-                return;
-            }
-
-            //LogDebug($"Handling diff, bulk {currentBulk}/{totalBulks}: {bulk.Action} {correctLevels.Length} levels");
-            switch (bulk.Action)
-            {
-                case OrderBookAction.Insert:
-                    UpdateLevels(correctLevels);
-                    break;
-                case OrderBookAction.Update:
-                    UpdateLevels(correctLevels);
-                    break;
-                case OrderBookAction.Delete:
-                    DeleteLevels(correctLevels);
-                    break;
-                default:
-                    return;
-            }
-        }
-
-        private bool IsCorrectType(CryptoOrderBookType bulkType)
+        /// <inheritdoc />
+        protected override bool IsForThis(OrderBookLevelBulk bulk)
         {
             if (TargetType == CryptoOrderBookType.All)
             {
@@ -556,10 +118,28 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
             }
 
             // handle only same type as selected
-            return TargetType == bulkType;
+            return TargetType == bulk.OrderBookType;
         }
 
-        private void UpdateLevels(OrderBookLevel[] levels)
+        /// <inheritdoc />
+        protected override void ClearLevels()
+        {
+            BidLevelsInternal.Clear();
+            _bidLevelOrdering.Clear();
+            AskLevelsInternal.Clear();
+            _askLevelOrdering.Clear();
+            AllBidLevels.Clear();
+            AllAskLevels.Clear();
+        }
+
+        /// <inheritdoc />
+        protected override void HandleSnapshotBidLevel(OrderBookLevel level) => InsertLevelIntoPriceGroup(level, BidLevelsInternal, _bidLevelOrdering);
+
+        /// <inheritdoc />
+        protected override void HandleSnapshotAskLevel(OrderBookLevel level) => InsertLevelIntoPriceGroup(level, AskLevelsInternal, _askLevelOrdering);
+
+        /// <inheritdoc />
+        protected override void UpdateLevels(IEnumerable<OrderBookLevel> levels)
         {
             foreach (var level in levels)
             {
@@ -582,29 +162,7 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
                 var previousPrice = existing.Price;
                 var previousAmount = existing.Amount;
 
-                var amountDiff = (level.Amount ?? existing.Amount ?? 0) - (existing.Amount ?? 0);
-                var countDiff = (level.Count ?? existing.Count ?? 0) - (existing.Count ?? 0);
-
-                existing.Price = level.Price ?? existing.Price;
-                existing.Amount = level.Amount ?? existing.Amount;
-                existing.Count = level.Count ?? existing.Count;
-                existing.Pair = level.Pair ?? existing.Pair;
-
-                level.AmountDifference = amountDiff;
-                existing.AmountDifference = amountDiff;
-
-                level.CountDifference = countDiff;
-                existing.CountDifference = countDiff;
-
-                level.AmountDifferenceAggregated += amountDiff;
-                existing.AmountDifferenceAggregated += amountDiff;
-
-                level.CountDifferenceAggregated += countDiff;
-                existing.CountDifferenceAggregated += countDiff;
-
-                level.Amount = level.Amount ?? existing.Amount;
-                level.Count = level.Count ?? existing.Count;
-                level.Price = level.Price ?? existing.Price;
+                ComputeUpdate(existing, level);
 
                 InsertToCollection(collection, ordering, existing, previousPrice, previousAmount);
             }
@@ -677,14 +235,8 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
             level.Ordering = ordering;
         }
 
-        private static bool IsInvalidLevel(OrderBookLevel level)
-        {
-            return string.IsNullOrWhiteSpace(level.Id) ||
-                   level.Price == null ||
-                   level.Amount == null;
-        }
-
-        private void DeleteLevels(OrderBookLevel[] levels)
+        /// <inheritdoc />
+        protected override void DeleteLevels(IReadOnlyCollection<OrderBookLevel> levels)
         {
             FillCurrentIndex(levels);
 
@@ -703,24 +255,7 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
                 {
                     var existing = allLevels[level.Id];
 
-                    var amountDiff = -(existing.Amount ?? 0);
-                    var countDiff = -(existing.Count ?? 0);
-
-                    level.Amount = level.Amount ?? existing.Amount;
-                    level.Count = level.Count ?? existing.Count;
-                    level.Price = level.Price ?? existing.Price;
-
-                    level.AmountDifference = amountDiff;
-                    existing.AmountDifference = amountDiff;
-
-                    level.CountDifference = countDiff;
-                    existing.CountDifference = countDiff;
-
-                    level.AmountDifferenceAggregated += amountDiff;
-                    existing.AmountDifferenceAggregated += amountDiff;
-
-                    level.CountDifferenceAggregated += countDiff;
-                    existing.CountDifferenceAggregated += countDiff;
+                    ComputeDelete(existing, level);
 
                     price = existing.Price ?? -1;
                     allLevels.Remove(level.Id);
@@ -741,313 +276,54 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
             }
         }
 
-        private void RecomputeAfterChange()
+        /// <inheritdoc />
+        protected override OrderBookLevel GetFirstBid()
         {
-            var bids = _bidLevels.Values.FirstOrDefault();
-            var firstBid = bids?.Count > 0 ? (OrderBookLevel)bids[0] : null;
-
-            var asks = _askLevels.Values.FirstOrDefault();
-            var firstAsk = asks?.Count > 0 ? (OrderBookLevel)asks[0] : null;
-
-            BidPrice = firstBid?.Price ?? 0;
-            BidAmount = firstBid?.Amount ?? 0;
-
-            AskPrice = firstAsk?.Price ?? 0;
-            AskAmount = firstAsk?.Amount ?? 0;
+            var bids = BidLevelsInternal.Values.FirstOrDefault();
+            return bids?.Count > 0 ? (OrderBookLevel)bids[0] : null;
         }
 
-        private void RecomputeAfterChangeAndSetIndexes(List<OrderBookLevel> levels)
+        /// <inheritdoc />
+        protected override OrderBookLevel GetFirstAsk()
         {
-            RecomputeAfterChange();
-            FillCurrentIndex(levels);
+            var asks = AskLevelsInternal.Values.FirstOrDefault();
+            return asks?.Count > 0 ? (OrderBookLevel)asks[0] : null;
         }
 
-        private void FillCurrentIndex(List<OrderBookLevel> levels)
+        /// <inheritdoc />
+        protected override OrderBookLevel[] ComputeBidLevels()
         {
-            if (!IsIndexComputationEnabled)
-                return;
-
-            foreach (var level in levels)
+            lock (Locker)
             {
-                FillIndex(level);
+                return BidLevelsInternal.Values.SelectMany(x => x.Values.Cast<OrderBookLevel>()).ToArray();
             }
         }
 
-        private void FillCurrentIndex(OrderBookLevel[] levels)
+        /// <inheritdoc />
+        protected override OrderBookLevel[] ComputeAskLevels()
         {
-            if (!IsIndexComputationEnabled)
-                return;
-
-            foreach (var level in levels)
+            lock (Locker)
             {
-                FillIndex(level);
-            }
-        }
-
-        private void FillIndex(OrderBookLevel level)
-        {
-            if (level.Index.HasValue)
-                return;
-
-            var price = level.Price;
-            if (price == null)
-            {
-                var all = GetAllCollection(level.Side);
-                var existing = all.ContainsKey(level.Id) ? all[level.Id] : null;
-                price = existing?.Price;
-            }
-
-            if (price == null)
-                return;
-
-            var collection = GetLevelsCollection(level.Side);
-            if (collection == null)
-                return;
-
-            var index = collection.IndexOfKey(price.Value);
-            level.Index = index;
-        }
-
-        private OrderBookLevel[] ComputeBidLevels()
-        {
-            lock (_locker)
-            {
-                return _bidLevels
-                    .Values
-                    .SelectMany(x => x.Values.Cast<OrderBookLevel>())
-                    .ToArray();
-            }
-        }
-
-        private OrderBookLevel[] ComputeAskLevels()
-        {
-            lock (_locker)
-            {
-                return _askLevels
-                    .Values
-                    .SelectMany(x => x.Values.Cast<OrderBookLevel>())
-                    .ToArray();
-            }
-        }
-
-        private OrderBookLevel[] ComputeAllLevels()
-        {
-            lock (_locker)
-            {
-                return _allBidLevels.Concat(_allAskLevels)
-                    .Select(x => x.Value)
-                    .ToArray();
+                return AskLevelsInternal.Values.SelectMany(x => x.Values.Cast<OrderBookLevel>()).ToArray();
             }
         }
 
         private IReadOnlyDictionary<double, OrderBookLevel[]> ComputeLevelsPerPrice(SortedList<double, OrderedDictionary> levels)
         {
-            lock (_locker)
+            lock (Locker)
             {
-                return levels
-                    .ToDictionary(x => x.Key,
-                        y => y.Value.Values.Cast<OrderBookLevel>().ToArray());
+                return levels.ToDictionary(x => x.Key, y => y.Value.Values.Cast<OrderBookLevel>().ToArray());
             }
-        }
-
-        private SortedList<double, OrderedDictionary> GetLevelsCollection(CryptoOrderSide side)
-        {
-            if (side == CryptoOrderSide.Undefined)
-                return null;
-            return side == CryptoOrderSide.Bid ?
-                _bidLevels :
-                _askLevels;
         }
 
         private OrderBookLevelsOrderPerPrice GetLevelsOrdering(CryptoOrderSide side)
         {
             if (side == CryptoOrderSide.Undefined)
                 return null;
-            return side == CryptoOrderSide.Bid ?
-                _bidLevelOrdering :
-                _askLevelOrdering;
-        }
 
-        private OrderBookLevelsById GetAllCollection(CryptoOrderSide side)
-        {
-            if (side == CryptoOrderSide.Undefined)
-                return null;
-            return side == CryptoOrderSide.Bid ?
-                _allBidLevels :
-                _allAskLevels;
-        }
-
-        private OrderBookChangeInfo CreateBookChangeNotification(List<OrderBookLevel> levels, OrderBookLevelBulk[] sources, bool isSnapshot)
-        {
-            var quotes = new CryptoQuotes(BidPrice, AskPrice, BidAmount, AskAmount);
-            var clonedLevels = DebugEnabled ? levels.Select(x => x.Clone()).ToArray() : new OrderBookLevel[0];
-            var lastSource = sources.LastOrDefault();
-            var change = new OrderBookChangeInfo(
-                TargetPair,
-                TargetPairOriginal,
-                quotes,
-                clonedLevels,
-                sources,
-                isSnapshot
-                )
-            {
-                ExchangeName = lastSource?.ExchangeName,
-                ServerSequence = lastSource?.ServerSequence,
-                ServerTimestamp = lastSource?.ServerTimestamp
-            };
-            return change;
-        }
-
-        private void NotifyIfBidAskChanged(double oldBid, double oldAsk, OrderBookChangeInfo info)
-        {
-            if (PriceChanged(oldBid, oldAsk, info))
-            {
-                _bidAskUpdated.OnNext(info);
-            }
-        }
-
-        private void NotifyIfTopLevelChanged(double oldBid, double oldAsk,
-            double oldBidAmount, double oldAskAmount,
-            OrderBookChangeInfo info)
-        {
-            if (PriceChanged(oldBid, oldAsk, info) || AmountChanged(oldBidAmount, oldAskAmount, info))
-            {
-                _topLevelUpdated.OnNext(info);
-            }
-        }
-
-        private static bool PriceChanged(double oldBid, double oldAsk, OrderBookChangeInfo info)
-        {
-            return !CryptoMathUtils.IsSame(oldBid, info.Quotes.Bid) ||
-                   !CryptoMathUtils.IsSame(oldAsk, info.Quotes.Ask);
-        }
-
-        private static bool AmountChanged(double oldBidAmount, double oldAskAmount, OrderBookChangeInfo info)
-        {
-            return !CryptoMathUtils.IsSame(oldBidAmount, info.Quotes.BidAmount) ||
-                   !CryptoMathUtils.IsSame(oldAskAmount, info.Quotes.AskAmount);
-        }
-
-        private async Task ReloadSnapshotWithCheck()
-        {
-            if (!_source.LoadSnapshotEnabled)
-            {
-                // snapshot loading disabled on the source, do nothing
-                return;
-            }
-
-            await ReloadSnapshot();
-        }
-
-        private async Task ReloadSnapshot()
-        {
-            try
-            {
-                DeactivateAutoSnapshotReloading();
-                DeactivateValidityChecking();
-                await _source.LoadSnapshot(TargetPairOriginal, 10000);
-            }
-            catch (Exception e)
-            {
-                LogAlways(e, $"Failed to reload snapshot for pair '{TargetPair}', " +
-                             $"error: {e.Message}");
-            }
-            finally
-            {
-                RestartAutoSnapshotReloading();
-                RestartValidityChecking();
-            }
-        }
-
-        private async Task CheckValidityAndReload()
-        {
-            var isValid = IsValid();
-            if (isValid)
-            {
-                // ob is valid, just reset counter and do nothing
-                _validityCheckCounter = 0;
-                return;
-            }
-
-            _validityCheckCounter++;
-            if (_validityCheckCounter < ValidityCheckLimit)
-            {
-                // invalid state, but still in the check limit interval
-                // waiting for confirmation
-                return;
-            }
-            _validityCheckCounter = 0;
-
-            LogAlways($"Order book is in invalid state, bid: {BidPrice}, ask: {AskPrice}, " +
-                         "reloading snapshot...");
-            await ReloadSnapshot();
-        }
-
-        private void RestartAutoSnapshotReloading()
-        {
-            DeactivateAutoSnapshotReloading();
-
-            if (!_snapshotReloadEnabled)
-            {
-                // snapshot reloading disabled, do not start timer
-                return;
-            }
-
-            var timerMs = (int)SnapshotReloadTimeout.TotalMilliseconds;
-            _snapshotReloadTimer = new Timer(async _ => await ReloadSnapshotWithCheck(),
-                null, timerMs, timerMs);
-        }
-
-        private void DeactivateAutoSnapshotReloading()
-        {
-            _snapshotReloadTimer?.Dispose();
-            _snapshotReloadTimer = null;
-        }
-
-        private void RestartValidityChecking()
-        {
-            DeactivateValidityChecking();
-
-            if (!_validityCheckEnabled)
-            {
-                // validity checking disabled, do not start timer
-                return;
-            }
-
-            var timerMs = (int)ValidityCheckTimeout.TotalMilliseconds;
-            _validityCheckTimer = new Timer(async _ => await CheckValidityAndReload(),
-                null, timerMs, timerMs);
-        }
-
-        private void DeactivateValidityChecking()
-        {
-            _validityCheckTimer?.Dispose();
-            _validityCheckTimer = null;
-        }
-
-        private void LogDebug(string msg)
-        {
-            if (!DebugLogEnabled)
-                return;
-            LogAlways(msg);
-        }
-
-        private void LogAlways(string msg)
-        {
-            _source.Logger.LogDebug("[ORDER BOOK {exchangeName} {targetPair}] {message}", ExchangeName, TargetPair, msg);
-        }
-
-        private void LogAlways(Exception e, string msg)
-        {
-            _source.Logger.LogDebug(e, "[ORDER BOOK {exchangeName} {targetPair}] {message}", ExchangeName, TargetPair, msg);
-        }
-
-        private class DescendingComparer : IComparer<double>
-        {
-            public int Compare(double x, double y)
-            {
-                return y.CompareTo(x);
-            }
+            return side == CryptoOrderSide.Bid
+                ? _bidLevelOrdering
+                : _askLevelOrdering;
         }
     }
 }

--- a/src/Crypto.Websocket.Extensions.Core/OrderBooks/CryptoOrderBookBase.cs
+++ b/src/Crypto.Websocket.Extensions.Core/OrderBooks/CryptoOrderBookBase.cs
@@ -1,0 +1,795 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using System.Threading.Tasks;
+using Crypto.Websocket.Extensions.Core.Models;
+using Crypto.Websocket.Extensions.Core.OrderBooks.Models;
+using Crypto.Websocket.Extensions.Core.OrderBooks.Sources;
+using Crypto.Websocket.Extensions.Core.Utils;
+using Crypto.Websocket.Extensions.Core.Validations;
+using Microsoft.Extensions.Logging;
+
+namespace Crypto.Websocket.Extensions.Core.OrderBooks
+{
+    /// <summary>
+    /// Base class for order books.
+    /// </summary>
+    public abstract class CryptoOrderBookBase<T> : ICryptoOrderBook
+    {
+        /// <summary>
+        /// Object to use for synchronization.
+        /// </summary>
+        protected readonly object Locker = new();
+
+        /// <summary>
+        /// The source.
+        /// </summary>
+        protected readonly IOrderBookSource Source;
+
+        /// <summary>
+        /// The internal collection of bid levels.
+        /// </summary>
+        protected readonly SortedList<double, T> BidLevelsInternal = new(new DescendingComparer());
+
+        /// <summary>
+        /// The internal collection of ask levels.
+        /// </summary>
+        protected readonly SortedList<double, T> AskLevelsInternal = new();
+
+        /// <summary>
+        /// Subject for streaming events when the top bid or ask price changes.
+        /// </summary>
+        protected readonly Subject<OrderBookChangeInfo> BidAskUpdated = new();
+
+        /// <summary>
+        /// Subject for streaming events when the top bid or ask prices or amounts change.
+        /// </summary>
+        protected readonly Subject<OrderBookChangeInfo> TopLevelUpdated = new();
+
+        /// <summary>
+        /// Subject for streaming events when any change is detected.
+        /// </summary>
+        protected readonly Subject<OrderBookChangeInfo> OrderBookUpdated = new();
+
+        /// <summary>
+        /// All the bid levels (not grouped by price).
+        /// </summary>
+        protected readonly OrderBookLevelsById AllBidLevels = new(500);
+
+        /// <summary>
+        /// All the ask levels (not grouped by price).
+        /// </summary>
+        protected readonly OrderBookLevelsById AllAskLevels = new(500);
+
+        bool _isSnapshotLoaded;
+        Timer _snapshotReloadTimer;
+        TimeSpan _snapshotReloadTimeout = TimeSpan.FromMinutes(1);
+        bool _snapshotReloadEnabled;
+
+        Timer _validityCheckTimer;
+        TimeSpan _validityCheckTimeout = TimeSpan.FromSeconds(5);
+        bool _validityCheckEnabled = true;
+        int _validityCheckCounter;
+
+        IDisposable _subscriptionDiff;
+        IDisposable _subscriptionSnapshot;
+
+        CryptoQuotes _previous;
+        CryptoQuotes _current;
+
+        /// <summary>
+        /// Cryptocurrency order book.
+        /// Process order book data from one source per one target pair.
+        /// </summary>
+        /// <param name="targetPair">Select target pair</param>
+        /// <param name="source">Provide source data</param>
+        protected CryptoOrderBookBase(string targetPair, IOrderBookSource source)
+        {
+            CryptoValidations.ValidateInput(targetPair, nameof(targetPair));
+            CryptoValidations.ValidateInput(source, nameof(source));
+
+            _previous = new CryptoQuotes(BidPrice, AskPrice, BidAmount, AskAmount);
+            _current = new CryptoQuotes(BidPrice, AskPrice, BidAmount, AskAmount);
+
+            TargetPairOriginal = targetPair;
+            TargetPair = CryptoPairsHelper.Clean(targetPair);
+            Source = source;
+        }
+
+        /// <summary>
+        /// Subscribes to source streams and starts background threads for
+        /// auto snapshot reloading and validity checking.
+        /// </summary>
+        protected void Initialize()
+        {
+            Subscribe();
+            RestartAutoSnapshotReloading();
+            RestartValidityChecking();
+        }
+
+        /// <summary>
+        /// Dispose background processing.
+        /// </summary>
+        public void Dispose()
+        {
+            DeactivateAutoSnapshotReloading();
+            DeactivateValidityChecking();
+            _subscriptionDiff?.Dispose();
+            _subscriptionSnapshot?.Dispose();
+            _snapshotReloadTimer?.Dispose();
+            _validityCheckTimer?.Dispose();
+        }
+
+        /// <inheritdoc />
+        public string ExchangeName => Source.ExchangeName;
+
+        /// <inheritdoc />
+        public string TargetPair { get; }
+
+        /// <inheritdoc />
+        public string TargetPairOriginal { get; }
+
+        /// <inheritdoc />
+        public CryptoOrderBookType TargetType { get; protected set; }
+
+        /// <inheritdoc />
+        public TimeSpan SnapshotReloadTimeout
+        {
+            get => _snapshotReloadTimeout;
+            set
+            {
+                _snapshotReloadTimeout = value;
+                RestartAutoSnapshotReloading();
+            }
+        }
+
+        /// <inheritdoc />
+        public bool SnapshotReloadEnabled
+        {
+            get => _snapshotReloadEnabled;
+            set
+            {
+                _snapshotReloadEnabled = value;
+                RestartAutoSnapshotReloading();
+            }
+        }
+
+        /// <inheritdoc />
+        public TimeSpan ValidityCheckTimeout
+        {
+            get => _validityCheckTimeout;
+            set
+            {
+                _validityCheckTimeout = value;
+                RestartValidityChecking();
+            }
+        }
+
+        /// <inheritdoc />
+        public int ValidityCheckLimit { get; set; } = 6;
+
+        /// <inheritdoc />
+        public bool ValidityCheckEnabled
+        {
+            get => _validityCheckEnabled;
+            set
+            {
+                _validityCheckEnabled = value;
+                RestartValidityChecking();
+            }
+        }
+
+        /// <inheritdoc />
+        public bool DebugEnabled { get; set; } = false;
+
+        /// <inheritdoc />
+        public bool DebugLogEnabled { get; set; } = false;
+
+        /// <inheritdoc />
+        public bool IsSnapshotLoaded => _isSnapshotLoaded;
+
+        /// <inheritdoc />
+        public bool IgnoreDiffsBeforeSnapshot { get; set; } = true;
+
+        /// <inheritdoc />
+        public bool IsIndexComputationEnabled { get; set; }
+
+        /// <inheritdoc />
+        public IObservable<IOrderBookChangeInfo> BidAskUpdatedStream => BidAskUpdated.AsObservable();
+
+        /// <inheritdoc />
+        public IObservable<IOrderBookChangeInfo> TopLevelUpdatedStream => TopLevelUpdated.AsObservable();
+
+        /// <inheritdoc />
+        public IObservable<IOrderBookChangeInfo> OrderBookUpdatedStream => OrderBookUpdated.AsObservable();
+
+        /// <inheritdoc />
+        public OrderBookLevel[] BidLevels => ComputeBidLevels();
+
+        /// <inheritdoc />
+        public OrderBookLevel[] AskLevels => ComputeAskLevels();
+
+        /// <inheritdoc />
+        public OrderBookLevel[] Levels => ComputeAllLevels();
+
+        /// <inheritdoc />
+        public double BidPrice { get; private set; }
+
+        /// <inheritdoc />
+        public double AskPrice { get; private set; }
+
+        /// <inheritdoc />
+        public double MidPrice => (AskPrice + BidPrice) / 2;
+
+        /// <inheritdoc />
+        public double BidAmount { get; private set; }
+
+        /// <inheritdoc />
+        public double AskAmount { get; private set; }
+
+        /// <inheritdoc />
+        public bool IsValid()
+        {
+            var isPriceValid = BidPrice <= AskPrice;
+            return isPriceValid && Source.IsValid();
+        }
+
+        /// <inheritdoc />
+        public abstract OrderBookLevel FindBidLevelByPrice(double price);
+
+        /// <inheritdoc />
+        public abstract OrderBookLevel[] FindBidLevelsByPrice(double price);
+
+        /// <inheritdoc />
+        public abstract OrderBookLevel FindAskLevelByPrice(double price);
+
+        /// <inheritdoc />
+        public abstract OrderBookLevel[] FindAskLevelsByPrice(double price);
+
+        /// <inheritdoc />
+        public OrderBookLevel FindBidLevelById(string id) => FindLevelById(id, CryptoOrderSide.Bid);
+
+        /// <inheritdoc />
+        public OrderBookLevel FindAskLevelById(string id) => FindLevelById(id, CryptoOrderSide.Ask);
+
+        /// <inheritdoc />
+        public OrderBookLevel FindLevelById(string id, CryptoOrderSide side)
+        {
+            if (side == CryptoOrderSide.Undefined)
+                return null;
+
+            var collection = GetAllCollection(side);
+            return collection.ContainsKey(id)
+                ? collection[id]
+                : null;
+        }
+
+        void Subscribe()
+        {
+            _subscriptionSnapshot = Source.OrderBookSnapshotStream.Subscribe(HandleSnapshotSynchronized);
+            _subscriptionDiff = Source.OrderBookStream.Subscribe(HandleDiffsSynchronized);
+        }
+
+        void HandleSnapshotSynchronized(OrderBookLevelBulk bulk)
+        {
+            if (bulk == null || !IsForThis(bulk))
+                return;
+
+            var levelsForThis = bulk.Levels.Where(x => TargetPair.Equals(x.Pair)).ToList();
+            if (!levelsForThis.Any())
+            {
+                // snapshot for different pair, ignore
+                return;
+            }
+
+            lock (Locker)
+            {
+                HandleSnapshot(levelsForThis);
+                var change = CreateBookChangeNotification(levelsForThis, new[] { bulk }, true);
+                NotifyOrderBookChanges(change);
+            }
+        }
+
+        /// <summary>
+        /// Is the bulk for this orderbook?
+        /// </summary>
+        /// <param name="bulk">The bulk.</param>
+        /// <returns>True if the bulk is for this orderbook.</returns>
+        protected abstract bool IsForThis(OrderBookLevelBulk bulk);
+
+        void HandleDiffsSynchronized(OrderBookLevelBulk[] bulks)
+        {
+            var sw = DebugEnabled ? Stopwatch.StartNew() : null;
+
+            var forThis = bulks.Where(x => x != null).Where(IsForThis).ToList();
+            if (!forThis.Any())
+            {
+                // diffs for different pair, ignore
+                return;
+            }
+
+            var allLevels = new List<OrderBookLevel>();
+
+            lock (Locker)
+            {
+                foreach (var bulk in forThis)
+                {
+                    var levelsForThis = bulk.Levels.Where(x => TargetPair.Equals(x.Pair)).ToList();
+                    allLevels.AddRange(levelsForThis);
+                    HandleDiff(bulk, levelsForThis);
+                }
+
+                if (allLevels.Any())
+                {
+                    RecomputeAfterChangeAndSetIndexes(allLevels);
+                    var change = CreateBookChangeNotification(allLevels, forThis, false);
+                    NotifyOrderBookChanges(change);
+                }
+
+                if (sw != null)
+                {
+                    var levels = forThis.SelectMany(x => x.Levels).Count();
+                    LogDebug($"Diff ({forThis.Count} bulks, {levels} levels) processing took {sw.ElapsedMilliseconds} ms, {sw.ElapsedTicks} ticks");
+                }
+            }
+        }
+
+        void NotifyOrderBookChanges(OrderBookChangeInfo info)
+        {
+            OrderBookUpdated.OnNext(info);
+
+            (_previous, _current) = (_current, _previous);
+
+            var bidAskChanged = NotifyIfBidAskChanged(info);
+            NotifyIfTopLevelChanged(bidAskChanged, info);
+            UpdateSnapshot(_current);
+        }
+
+        void HandleSnapshot(List<OrderBookLevel> levels)
+        {
+            ClearLevels();
+
+            LogDebug($"Handling snapshot: {levels.Count} levels");
+            foreach (var level in levels)
+            {
+                var price = level.Price;
+                if (price is null or < 0)
+                {
+                    LogAlways($"Received snapshot level with weird price, ignoring. [{level.Side}] Id: {level.Id}, price: {level.Price}, amount: {level.Amount}");
+                    continue;
+                }
+
+                level.AmountDifference = level.Amount ?? 0;
+                level.CountDifference = level.Count ?? 0;
+
+                switch (level.Side)
+                {
+                    case CryptoOrderSide.Bid:
+                        HandleSnapshotBidLevel(level);
+                        AllBidLevels[level.Id] = level;
+                        break;
+                    case CryptoOrderSide.Ask:
+                        HandleSnapshotAskLevel(level);
+                        AllAskLevels[level.Id] = level;
+                        break;
+                }
+            }
+
+            RecomputeAfterChangeAndSetIndexes(levels);
+
+            _isSnapshotLoaded = true;
+        }
+
+        void UpdateSnapshot(CryptoQuotes snapshot)
+        {
+            snapshot.Bid = BidPrice;
+            snapshot.Ask = AskPrice;
+            snapshot.BidAmount = BidAmount;
+            snapshot.AskAmount = AskAmount;
+        }
+
+        /// <summary>
+        /// Clears all internal levels state. Called at the beginning of handling a snapshot.
+        /// </summary>
+        protected abstract void ClearLevels();
+
+        /// <summary>
+        /// Handle a bid level for a snapshot.
+        /// </summary>
+        /// <param name="level">The bid level.</param>
+        protected abstract void HandleSnapshotBidLevel(OrderBookLevel level);
+
+        /// <summary>
+        /// Handle an ask level for a snapshot.
+        /// </summary>
+        /// <param name="level">The ask level.</param>
+        protected abstract void HandleSnapshotAskLevel(OrderBookLevel level);
+
+        void HandleDiff(OrderBookLevelBulk bulk, IReadOnlyCollection<OrderBookLevel> correctLevels)
+        {
+            if (IgnoreDiffsBeforeSnapshot && !_isSnapshotLoaded)
+            {
+                LogDebug($"Snapshot not loaded yet, ignoring bulk: {bulk.Action} {correctLevels.Count} levels");
+                // snapshot is not loaded yet, ignore data
+                return;
+            }
+
+            //LogDebug($"Handling diff, bulk {currentBulk}/{totalBulks}: {bulk.Action} {correctLevels.Length} levels");
+            switch (bulk.Action)
+            {
+                case OrderBookAction.Insert:
+                    UpdateLevels(correctLevels);
+                    break;
+                case OrderBookAction.Update:
+                    UpdateLevels(correctLevels);
+                    break;
+                case OrderBookAction.Delete:
+                    DeleteLevels(correctLevels);
+                    break;
+                default:
+                    return;
+            }
+        }
+
+        /// <summary>
+        /// Updates internal state levels.
+        /// </summary>
+        /// <param name="levels">The levels to update.</param>
+        protected abstract void UpdateLevels(IEnumerable<OrderBookLevel> levels);
+
+        /// <summary>
+        /// Computes differences and copies state between existing and new level.
+        /// </summary>
+        /// <param name="existing">The existing level.</param>
+        /// <param name="level">The new level.</param>
+        protected static void ComputeUpdate(OrderBookLevel existing, OrderBookLevel level)
+        {
+            var amountDiff = (level.Amount ?? existing.Amount ?? 0) - (existing.Amount ?? 0);
+            var countDiff = (level.Count ?? existing.Count ?? 0) - (existing.Count ?? 0);
+
+            existing.Price = level.Price ?? existing.Price;
+            existing.Amount = level.Amount ?? existing.Amount;
+            existing.Count = level.Count ?? existing.Count;
+            existing.Pair = level.Pair ?? existing.Pair;
+
+            level.AmountDifference = amountDiff;
+            existing.AmountDifference = amountDiff;
+
+            level.CountDifference = countDiff;
+            existing.CountDifference = countDiff;
+
+            level.AmountDifferenceAggregated += amountDiff;
+            existing.AmountDifferenceAggregated += amountDiff;
+
+            level.CountDifferenceAggregated += countDiff;
+            existing.CountDifferenceAggregated += countDiff;
+
+            level.Amount ??= existing.Amount;
+            level.Count ??= existing.Count;
+            level.Price ??= existing.Price;
+        }
+
+        /// <summary>
+        /// Decides whether or not a level is valid.
+        /// </summary>
+        /// <param name="level">The level to check.</param>
+        /// <returns>True if the given level is valid.</returns>
+        protected static bool IsInvalidLevel(OrderBookLevel level) =>
+            string.IsNullOrWhiteSpace(level.Id) ||
+            level.Price == null ||
+            level.Amount == null;
+
+        /// <summary>
+        /// Deletes internal state levels.
+        /// </summary>
+        /// <param name="levels">The levels to delete.</param>
+        protected abstract void DeleteLevels(IReadOnlyCollection<OrderBookLevel> levels);
+
+        /// <summary>
+        /// Computes differences and copies state between existing and new level.
+        /// </summary>
+        /// <param name="existing">The existing level.</param>
+        /// <param name="level">The new level.</param>
+        protected static void ComputeDelete(OrderBookLevel existing, OrderBookLevel level)
+        {
+            var amountDiff = -(existing.Amount ?? 0);
+            var countDiff = -(existing.Count ?? 0);
+
+            level.Amount ??= existing.Amount;
+            level.Count ??= existing.Count;
+            level.Price ??= existing.Price;
+
+            level.AmountDifference = amountDiff;
+            existing.AmountDifference = amountDiff;
+
+            level.CountDifference = countDiff;
+            existing.CountDifference = countDiff;
+
+            level.AmountDifferenceAggregated += amountDiff;
+            existing.AmountDifferenceAggregated += amountDiff;
+
+            level.CountDifferenceAggregated += countDiff;
+            existing.CountDifferenceAggregated += countDiff;
+        }
+
+        void RecomputeAfterChange()
+        {
+            var firstBid = GetFirstBid();
+            var firstAsk = GetFirstAsk();
+
+            BidPrice = firstBid?.Price ?? 0;
+            BidAmount = firstBid?.Amount ?? 0;
+
+            AskPrice = firstAsk?.Price ?? 0;
+            AskAmount = firstAsk?.Amount ?? 0;
+        }
+
+        /// <summary>
+        /// Gets the first bid.
+        /// </summary>
+        /// <returns>The first bid.</returns>
+        protected abstract OrderBookLevel GetFirstBid();
+
+        /// <summary>
+        /// Gets the first ask.
+        /// </summary>
+        /// <returns>The first ask.</returns>
+        protected abstract OrderBookLevel GetFirstAsk();
+
+        void RecomputeAfterChangeAndSetIndexes(IEnumerable<OrderBookLevel> levels)
+        {
+            RecomputeAfterChange();
+            FillCurrentIndex(levels);
+        }
+
+        /// <summary>
+        /// Fills the current index.
+        /// </summary>
+        /// <param name="levels">The levels to use.</param>
+        protected void FillCurrentIndex(IEnumerable<OrderBookLevel> levels)
+        {
+            if (!IsIndexComputationEnabled)
+                return;
+
+            foreach (var level in levels)
+                FillIndex(level);
+        }
+
+        void FillIndex(OrderBookLevel level)
+        {
+            if (level.Index.HasValue)
+                return;
+
+            var price = level.Price;
+            if (price == null)
+            {
+                var all = GetAllCollection(level.Side);
+                var existing = all.ContainsKey(level.Id) ? all[level.Id] : null;
+                price = existing?.Price;
+            }
+
+            if (price == null)
+                return;
+
+            var collection = GetLevelsCollection(level.Side);
+            if (collection == null)
+                return;
+
+            var index = collection.IndexOfKey(price.Value);
+            level.Index = index;
+        }
+
+        /// <summary>
+        /// Gets the levels collection for the specified side.
+        /// </summary>
+        /// <param name="side">The side.</param>
+        /// <returns>The levels for the specified side.</returns>
+        protected SortedList<double, T> GetLevelsCollection(CryptoOrderSide side)
+        {
+            if (side == CryptoOrderSide.Undefined)
+                return null;
+
+            return side == CryptoOrderSide.Bid
+                ? BidLevelsInternal
+                : AskLevelsInternal;
+        }
+
+        /// <summary>
+        /// Calculates the bid levels.
+        /// </summary>
+        /// <returns>The computed bids.</returns>
+        protected abstract OrderBookLevel[] ComputeBidLevels();
+
+        /// <summary>
+        /// Calculates the ask levels.
+        /// </summary>
+        /// <returns>The computed asks.</returns>
+        protected abstract OrderBookLevel[] ComputeAskLevels();
+
+        OrderBookLevel[] ComputeAllLevels()
+        {
+            lock (Locker)
+            {
+                return AllBidLevels.Concat(AllAskLevels).Select(x => x.Value).ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Get all the levels for the specified side.
+        /// </summary>
+        /// <param name="side">The side.</param>
+        /// <returns>All the levels for the specified side.</returns>
+        protected OrderBookLevelsById GetAllCollection(CryptoOrderSide side)
+        {
+            if (side == CryptoOrderSide.Undefined)
+                return null;
+
+            return side == CryptoOrderSide.Bid
+                ? AllBidLevels
+                : AllAskLevels;
+        }
+
+        OrderBookChangeInfo CreateBookChangeNotification(IEnumerable<OrderBookLevel> levels, IReadOnlyList<OrderBookLevelBulk> sources, bool isSnapshot)
+        {
+            var quotes = new CryptoQuotes(BidPrice, AskPrice, BidAmount, AskAmount);
+            var clonedLevels = DebugEnabled ? levels.Select(x => x.Clone()).ToArray() : Array.Empty<OrderBookLevel>();
+            var lastSource = sources.LastOrDefault();
+            var change = new OrderBookChangeInfo(TargetPair, TargetPairOriginal, quotes, clonedLevels, sources, isSnapshot)
+            {
+                ExchangeName = lastSource?.ExchangeName,
+                ServerSequence = lastSource?.ServerSequence,
+                ServerTimestamp = lastSource?.ServerTimestamp
+            };
+            return change;
+        }
+
+        bool NotifyIfBidAskChanged(OrderBookChangeInfo info)
+        {
+            if (!CryptoMathUtils.IsSame(_previous.Bid, info.Quotes.Bid) ||
+                !CryptoMathUtils.IsSame(_previous.Ask, info.Quotes.Ask))
+            {
+                BidAskUpdated.OnNext(info);
+                return true;
+            }
+            return false;
+        }
+
+        bool NotifyIfTopLevelChanged(bool bidAskChanged, OrderBookChangeInfo info)
+        {
+            if (bidAskChanged ||
+                !CryptoMathUtils.IsSame(_previous.BidAmount, info.Quotes.BidAmount) ||
+                !CryptoMathUtils.IsSame(_previous.AskAmount, info.Quotes.AskAmount))
+            {
+                TopLevelUpdated.OnNext(info);
+                return true;
+            }
+            return false;
+        }
+
+        async Task ReloadSnapshotWithCheck()
+        {
+            if (!Source.LoadSnapshotEnabled)
+            {
+                // snapshot loading disabled on the source, do nothing
+                return;
+            }
+
+            await ReloadSnapshot();
+        }
+
+        async Task ReloadSnapshot()
+        {
+            try
+            {
+                DeactivateAutoSnapshotReloading();
+                DeactivateValidityChecking();
+                await Source.LoadSnapshot(TargetPairOriginal, 10000);
+            }
+            catch (Exception e)
+            {
+                LogAlways(e, $"Failed to reload snapshot for pair '{TargetPair}', error: {e.Message}");
+            }
+            finally
+            {
+                RestartAutoSnapshotReloading();
+                RestartValidityChecking();
+            }
+        }
+
+        async Task CheckValidityAndReload()
+        {
+            var isValid = IsValid();
+            if (isValid)
+            {
+                // ob is valid, just reset counter and do nothing
+                _validityCheckCounter = 0;
+                return;
+            }
+
+            _validityCheckCounter++;
+            if (_validityCheckCounter < ValidityCheckLimit)
+            {
+                // invalid state, but still in the check limit interval
+                // waiting for confirmation
+                return;
+            }
+            _validityCheckCounter = 0;
+
+            LogAlways($"Order book is in invalid state, bid: {BidPrice}, ask: {AskPrice}, reloading snapshot...");
+            await ReloadSnapshot();
+        }
+
+        void RestartAutoSnapshotReloading()
+        {
+            DeactivateAutoSnapshotReloading();
+
+            if (!_snapshotReloadEnabled)
+            {
+                // snapshot reloading disabled, do not start timer
+                return;
+            }
+
+            _snapshotReloadTimer = new Timer(async _ => await ReloadSnapshotWithCheck(), null, SnapshotReloadTimeout, SnapshotReloadTimeout);
+        }
+
+        void DeactivateAutoSnapshotReloading()
+        {
+            _snapshotReloadTimer?.Dispose();
+            _snapshotReloadTimer = null;
+        }
+
+        void RestartValidityChecking()
+        {
+            DeactivateValidityChecking();
+
+            if (!_validityCheckEnabled)
+            {
+                // validity checking disabled, do not start timer
+                return;
+            }
+
+            _validityCheckTimer = new Timer(async _ => await CheckValidityAndReload(), null, ValidityCheckTimeout, ValidityCheckTimeout);
+        }
+
+        void DeactivateValidityChecking()
+        {
+            _validityCheckTimer?.Dispose();
+            _validityCheckTimer = null;
+        }
+
+        /// <summary>
+        /// Log a message if DebugLogEnabled is true.
+        /// </summary>
+        /// <param name="msg">The message.</param>
+        protected void LogDebug(string msg)
+        {
+            if (DebugLogEnabled)
+                LogAlways(msg);
+        }
+
+        /// <summary>
+        /// Always log a message.
+        /// </summary>
+        /// <param name="msg">The message.</param>
+        protected void LogAlways(string msg) => Source.Logger.LogDebug("[ORDER BOOK {exchangeName} {targetPair}] {message}", ExchangeName, TargetPair, msg);
+
+        /// <summary>
+        /// Always log an exception.
+        /// </summary>
+        /// <param name="e">The exception.</param>
+        /// <param name="msg">The message.</param>
+        protected void LogAlways(Exception e, string msg) => Source.Logger.LogDebug(e, "[ORDER BOOK {exchangeName} {targetPair}] {message}", ExchangeName, TargetPair, msg);
+
+        private class DescendingComparer : IComparer<double>
+        {
+	        public int Compare(double x, double y)
+	        {
+		        return y.CompareTo(x);
+	        }
+        }
+    }
+}

--- a/src/Crypto.Websocket.Extensions.Core/OrderBooks/CryptoOrderBookL2.cs
+++ b/src/Crypto.Websocket.Extensions.Core/OrderBooks/CryptoOrderBookL2.cs
@@ -18,495 +18,83 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
     /// <summary>
     /// Cryptocurrency order book optimized for L2 precision (grouped by price).
     /// Process order book data from one source and one target pair.
-    /// Only first levels are computed in advance, allocates less memory than CryptoOrderBook counterpart. 
+    /// Only first levels are computed in advance, allocates less memory than CryptoOrderBook counterpart.
     /// </summary>
-    [DebuggerDisplay("CryptoOrderBook [{TargetPair}] bid: {BidPrice} ({_bidLevels.Count}) ask: {AskPrice} ({_askLevels.Count})")]
-    public class CryptoOrderBookL2 : ICryptoOrderBook
+    [DebuggerDisplay("CryptoOrderBook [{TargetPair}] bid: {BidPrice} ({BidLevelsInternal.Count}) ask: {AskPrice} ({AskLevelsInternal.Count})")]
+    public class CryptoOrderBookL2 : CryptoOrderBookBase<OrderBookLevel>
     {
-        private readonly object _locker = new object();
-
-        private readonly IOrderBookSource _source;
-
-        private readonly Subject<OrderBookChangeInfo> _bidAskUpdated = new Subject<OrderBookChangeInfo>();
-        private readonly Subject<OrderBookChangeInfo> _topLevelUpdated = new Subject<OrderBookChangeInfo>();
-        private readonly Subject<OrderBookChangeInfo> _orderBookUpdated = new Subject<OrderBookChangeInfo>();
-
-        private readonly SortedList<double, OrderBookLevel> _bidLevels = new SortedList<double, OrderBookLevel>(new DescendingComparer());
-        private readonly SortedList<double, OrderBookLevel> _askLevels = new SortedList<double, OrderBookLevel>();
-
-        private readonly OrderBookLevelsById _allBidLevels = new OrderBookLevelsById(500);
-        private readonly OrderBookLevelsById _allAskLevels = new OrderBookLevelsById(500);
-
-        private bool _isSnapshotLoaded;
-        private Timer _snapshotReloadTimer;
-        private TimeSpan _snapshotReloadTimeout = TimeSpan.FromMinutes(1);
-        private bool _snapshotReloadEnabled;
-
-        private Timer _validityCheckTimer;
-        private TimeSpan _validityCheckTimeout = TimeSpan.FromSeconds(5);
-        private bool _validityCheckEnabled = true;
-        private int _validityCheckCounter;
-
-        private IDisposable _subscriptionDiff;
-        private IDisposable _subscriptionSnapshot;
-
         /// <summary>
         /// Cryptocurrency order book.
         /// Process order book data from one source per one target pair. 
         /// </summary>
         /// <param name="targetPair">Select target pair</param>
         /// <param name="source">Provide level 2 source data</param>
-        public CryptoOrderBookL2(string targetPair, IOrderBookSource source)
+        public CryptoOrderBookL2(string targetPair, IOrderBookSource source) : base(targetPair, source)
         {
-            CryptoValidations.ValidateInput(targetPair, nameof(targetPair));
-            CryptoValidations.ValidateInput(source, nameof(source));
-
-            TargetPairOriginal = targetPair;
-            TargetPair = CryptoPairsHelper.Clean(targetPair);
-            _source = source;
-
-            Subscribe();
-            RestartAutoSnapshotReloading();
-            RestartValidityChecking();
+            TargetType = CryptoOrderBookType.L2;
+            Initialize();
         }
 
-        /// <summary>
-        /// Dispose background processing
-        /// </summary>
-        public void Dispose()
+        /// <inheritdoc />
+        public override OrderBookLevel FindBidLevelByPrice(double price)
         {
-            DeactivateAutoSnapshotReloading();
-            DeactivateValidityChecking();
-            _source.Dispose();
-            _subscriptionDiff?.Dispose();
-            _subscriptionSnapshot?.Dispose();
-        }
-
-        /// <summary>
-        /// Origin exchange name
-        /// </summary>
-        public string ExchangeName => _source.ExchangeName;
-
-        /// <summary>
-        /// Target pair for this order book data
-        /// </summary>
-        public string TargetPair { get; }
-
-        /// <summary>
-        /// Originally provided target pair for this order book data
-        /// </summary>
-        public string TargetPairOriginal { get; }
-
-        /// <summary>
-        /// Order book type, which precision it supports
-        /// </summary>
-        public CryptoOrderBookType TargetType => CryptoOrderBookType.L2;
-
-        /// <summary>
-        /// Time interval for auto snapshot reloading.
-        /// Default 1 min. 
-        /// </summary>
-        public TimeSpan SnapshotReloadTimeout
-        {
-            get => _snapshotReloadTimeout;
-            set
+            lock (Locker)
             {
-                _snapshotReloadTimeout = value;
-                RestartAutoSnapshotReloading();
+                return BidLevelsInternal.TryGetValue(price, out var level)
+                    ? level
+                    : null;
             }
         }
 
-        /// <summary>
-        /// Whenever auto snapshot reloading feature is enabled.
-        /// Disabled by default
-        /// </summary>
-        public bool SnapshotReloadEnabled
-        {
-            get => _snapshotReloadEnabled;
-            set
-            {
-                _snapshotReloadEnabled = value;
-                RestartAutoSnapshotReloading();
-            }
-        }
-
-        /// <summary>
-        /// Time interval for validity checking.
-        /// It forces snapshot reloading whenever invalid state. 
-        /// Default 5 sec. 
-        /// </summary>
-        public TimeSpan ValidityCheckTimeout
-        {
-            get => _validityCheckTimeout;
-            set
-            {
-                _validityCheckTimeout = value;
-                RestartValidityChecking();
-            }
-        }
-
-        /// <summary>
-        /// How many times it should check validity before processing snapshot reload.
-        /// Default 6 times (which is 6 * 5sec = 30sec).
-        /// </summary>
-        public int ValidityCheckLimit { get; set; } = 6;
-
-        /// <summary>
-        /// Whenever validity checking feature is enabled.
-        /// It forces snapshot reloading whenever invalid state. 
-        /// Enabled by default
-        /// </summary>
-        public bool ValidityCheckEnabled
-        {
-            get => _validityCheckEnabled;
-            set
-            {
-                _validityCheckEnabled = value;
-                RestartValidityChecking();
-            }
-        }
-
-        /// <summary>
-        /// Provide more info (on every change) whenever enabled. 
-        /// Disabled by default
-        /// </summary>
-        public bool DebugEnabled { get; set; } = false;
-
-        /// <summary>
-        /// Logs more info (state, performance) whenever enabled. 
-        /// Disabled by default
-        /// </summary>
-        public bool DebugLogEnabled { get; set; }
-
-
-        /// <summary>
-        /// Whenever snapshot was already handled
-        /// </summary>
-        public bool IsSnapshotLoaded => _isSnapshotLoaded;
-
-        /// <summary>
-        /// All diffs/deltas that come before snapshot will be ignored (default: true)
-        /// </summary>
-        public bool IgnoreDiffsBeforeSnapshot { get; set; } = true;
-
-        /// <summary>
-        /// Compute index (position) per every updated level, performance is slightly reduced (default: false) 
-        /// </summary>
-        public bool IsIndexComputationEnabled { get; set; }
-
-        /// <summary>
-        /// Streams data when top level bid or ask price was updated
-        /// </summary>
-        public IObservable<IOrderBookChangeInfo> BidAskUpdatedStream => _bidAskUpdated.AsObservable();
-
-        /// <summary>
-        /// Streams data when top level bid or ask price or amount was updated
-        /// </summary>
-        public IObservable<IOrderBookChangeInfo> TopLevelUpdatedStream => _topLevelUpdated.AsObservable();
-
-        /// <summary>
-        /// Streams data on every order book change (price or amount at any level)
-        /// </summary>
-        public IObservable<IOrderBookChangeInfo> OrderBookUpdatedStream => _orderBookUpdated.AsObservable();
-
-        /// <summary>
-        /// Current bid side of the order book (ordered from higher to lower price)
-        /// </summary>
-        public OrderBookLevel[] BidLevels => ComputeBidLevels();
-
-        /// <summary>
-        /// Current ask side of the order book (ordered from lower to higher price)
-        /// </summary>
-        public OrderBookLevel[] AskLevels => ComputeAskLevels();
-
-        /// <summary>
-        /// All current levels together
-        /// </summary>
-        public OrderBookLevel[] Levels => ComputeAllLevels();
-
-        /// <summary>
-        /// Current top level bid price
-        /// </summary>
-        public double BidPrice { get; private set; }
-
-        /// <summary>
-        /// Current top level ask price
-        /// </summary>
-        public double AskPrice { get; private set; }
-
-        /// <summary>
-        /// Current mid price
-        /// </summary>
-        public double MidPrice => (AskPrice + BidPrice) / 2;
-
-        /// <summary>
-        /// Current top level bid amount
-        /// </summary>
-        public double BidAmount { get; private set; }
-
-        /// <summary>
-        /// Current top level ask price
-        /// </summary>
-        public double AskAmount { get; private set; }
-
-        /// <summary>
-        /// Returns true if order book is in valid state
-        /// </summary>
-        public bool IsValid()
-        {
-            var isPriceValid = BidPrice <= AskPrice;
-            return isPriceValid && _source.IsValid();
-        }
-
-        /// <summary>
-        /// Find bid level by provided price (returns null in case of not found)
-        /// </summary>
-        public OrderBookLevel FindBidLevelByPrice(double price)
-        {
-            lock (_locker)
-            {
-                return _bidLevels.TryGetValue(price, out OrderBookLevel level) ? level : null;
-            }
-        }
-
-        /// <summary>
-        /// Find all bid levels for provided price (returns empty when not found)
-        /// </summary>
-        public OrderBookLevel[] FindBidLevelsByPrice(double price)
+        /// <inheritdoc />
+        public override OrderBookLevel[] FindBidLevelsByPrice(double price)
         {
             var level = FindBidLevelByPrice(price);
-            if (level == null)
-                return Array.Empty<OrderBookLevel>();
-            return new[] { level };
+            return level == null
+                ? Array.Empty<OrderBookLevel>()
+                : new[] { level };
         }
 
-        /// <summary>
-        /// Find ask level by provided price (returns null in case of not found)
-        /// </summary>
-        public OrderBookLevel FindAskLevelByPrice(double price)
+        /// <inheritdoc />
+        public override OrderBookLevel FindAskLevelByPrice(double price)
         {
-            lock (_locker)
+            lock (Locker)
             {
-                return _askLevels.TryGetValue(price, out OrderBookLevel level) ? level : null;
+                return AskLevelsInternal.TryGetValue(price, out var level)
+                    ? level
+                    : null;
             }
         }
 
-        /// <summary>
-        /// Find all ask levels for provided price (returns empty when not found)
-        /// </summary>
-        public OrderBookLevel[] FindAskLevelsByPrice(double price)
+        /// <inheritdoc />
+        public override OrderBookLevel[] FindAskLevelsByPrice(double price)
         {
             var level = FindAskLevelByPrice(price);
-            if (level == null)
-                return Array.Empty<OrderBookLevel>();
-            return new[] { level };
+            return level == null
+                ? Array.Empty<OrderBookLevel>()
+                : new[] { level };
         }
 
-        /// <summary>
-        /// Find bid level by provided identification (returns null in case of not found)
-        /// </summary>
-        public OrderBookLevel FindBidLevelById(string id)
+        /// <inheritdoc />
+        protected override bool IsForThis(OrderBookLevelBulk bulk) => bulk.OrderBookType is CryptoOrderBookType.L1 or CryptoOrderBookType.L2;
+
+        /// <inheritdoc />
+        protected override void ClearLevels()
         {
-            return FindLevelById(id, CryptoOrderSide.Bid);
+            BidLevelsInternal.Clear();
+            AskLevelsInternal.Clear();
+            AllBidLevels.Clear();
+            AllAskLevels.Clear();
         }
 
-        /// <summary>
-        /// Find ask level by provided identification (returns null in case of not found)
-        /// </summary>
-        public OrderBookLevel FindAskLevelById(string id)
-        {
-            return FindLevelById(id, CryptoOrderSide.Ask);
-        }
+        /// <inheritdoc />
+        protected override void HandleSnapshotBidLevel(OrderBookLevel level) => BidLevelsInternal[level.Price!.Value] = level;
 
-        /// <summary>
-        /// Find level by provided identification (returns null in case of not found).
-        /// You need to specify side.
-        /// </summary>
-        public OrderBookLevel FindLevelById(string id, CryptoOrderSide side)
-        {
-            if (side == CryptoOrderSide.Undefined)
-                return null;
-            var collection = GetAllCollection(side);
-            if (collection.ContainsKey(id))
-                return collection[id];
-            return null;
-        }
+        /// <inheritdoc />
+        protected override void HandleSnapshotAskLevel(OrderBookLevel level) => AskLevelsInternal[level.Price!.Value] = level;
 
-        private void Subscribe()
-        {
-            _subscriptionSnapshot = _source
-                .OrderBookSnapshotStream
-                .Subscribe(HandleSnapshotSynchronized);
-
-            _subscriptionDiff = _source
-                .OrderBookStream
-                .Subscribe(HandleDiffSynchronized);
-        }
-
-        private void HandleSnapshotSynchronized(OrderBookLevelBulk bulk)
-        {
-            if (bulk == null)
-                return;
-
-            var levels = bulk.Levels;
-            var levelsForThis = levels
-                .Where(x => TargetPair.Equals(x.Pair))
-                .ToList();
-            if (!levelsForThis.Any())
-            {
-                // snapshot for different pair, ignore
-                return;
-            }
-
-            double oldBid;
-            double oldAsk;
-            double oldBidAmount;
-            double oldAskAmount;
-            OrderBookChangeInfo change;
-
-            lock (_locker)
-            {
-                oldBid = BidPrice;
-                oldAsk = AskPrice;
-                oldBidAmount = BidAmount;
-                oldAskAmount = AskAmount;
-                HandleSnapshot(levelsForThis);
-
-                change = NotifyAboutBookChange(
-                    levelsForThis,
-                    new[] { bulk },
-                    true
-                );
-            }
-
-            _orderBookUpdated.OnNext(change);
-            NotifyIfBidAskChanged(oldBid, oldAsk, change);
-            NotifyIfTopLevelChanged(oldBid, oldAsk, oldBidAmount, oldAskAmount, change);
-        }
-
-        private void HandleDiffSynchronized(OrderBookLevelBulk[] bulks)
-        {
-            var sw = DebugEnabled ? Stopwatch.StartNew() : null;
-
-            var forThis = bulks
-                .Where(x => x != null)
-                .Where(x => x.Levels.Any(y => TargetPair.Equals(y.Pair)))
-                .ToArray();
-            if (!forThis.Any())
-            {
-                // snapshot for different pair, ignore
-                return;
-            }
-
-            double oldBid;
-            double oldAsk;
-            double oldBidAmount;
-            double oldAskAmount;
-            var allLevels = new List<OrderBookLevel>();
-            OrderBookChangeInfo change;
-
-            lock (_locker)
-            {
-                oldBid = BidPrice;
-                oldAsk = AskPrice;
-                oldBidAmount = BidAmount;
-                oldAskAmount = AskAmount;
-
-                foreach (var bulk in forThis)
-                {
-                    var levelsForThis = bulk.Levels
-                        .Where(x => TargetPair.Equals(x.Pair))
-                        .ToArray();
-                    allLevels.AddRange(levelsForThis);
-                    HandleDiff(bulk, levelsForThis);
-                }
-
-                RecomputeAfterChangeAndSetIndexes(allLevels);
-
-                change = NotifyAboutBookChange(
-                    allLevels,
-                    forThis,
-                    false
-                );
-            }
-
-            _orderBookUpdated.OnNext(change);
-            NotifyIfTopLevelChanged(oldBid, oldAsk, oldBidAmount, oldAskAmount, change);
-            NotifyIfBidAskChanged(oldBid, oldAsk, change);
-
-            if (sw != null)
-            {
-                var levels = forThis.SelectMany(x => x.Levels).Count();
-                LogDebug($"Diff ({forThis.Length} bulks, {levels} levels) processing took {sw.ElapsedMilliseconds} ms, {sw.ElapsedTicks} ticks");
-            }
-        }
-
-        private void HandleSnapshot(List<OrderBookLevel> levels)
-        {
-            _bidLevels.Clear();
-            _askLevels.Clear();
-            _allBidLevels.Clear();
-            _allAskLevels.Clear();
-
-            LogDebug($"Handling snapshot: {levels.Count} levels");
-            foreach (var level in levels)
-            {
-                var price = level.Price;
-                if (price == null || price < 0)
-                {
-                    LogAlways($"Received snapshot level with weird price, ignoring. Id: {level.Id}, price: {level.Price}, amount: {level.Amount}");
-                    continue;
-                }
-
-                level.AmountDifference = level.Amount ?? 0;
-                level.CountDifference = level.Count ?? 0;
-
-                if (level.Side == CryptoOrderSide.Bid)
-                {
-                    _bidLevels[price.Value] = level;
-                    _allBidLevels[level.Id] = level;
-                }
-
-
-                if (level.Side == CryptoOrderSide.Ask)
-                {
-                    _askLevels[price.Value] = level;
-                    _allAskLevels[level.Id] = level;
-                }
-            }
-
-            RecomputeAfterChangeAndSetIndexes(levels);
-
-            _isSnapshotLoaded = true;
-        }
-
-        private void HandleDiff(OrderBookLevelBulk bulk, OrderBookLevel[] correctLevels)
-        {
-            if (IgnoreDiffsBeforeSnapshot && !_isSnapshotLoaded)
-            {
-                LogDebug($"Snapshot not loaded yet, ignoring bulk: {bulk.Action} {correctLevels.Length} levels");
-                // snapshot is not loaded yet, ignore data
-                return;
-            }
-
-            //LogDebug($"Handling diff, bulk {currentBulk}/{totalBulks}: {bulk.Action} {correctLevels.Length} levels");
-            switch (bulk.Action)
-            {
-                case OrderBookAction.Insert:
-                    UpdateLevels(correctLevels);
-                    break;
-                case OrderBookAction.Update:
-                    UpdateLevels(correctLevels);
-                    break;
-                case OrderBookAction.Delete:
-                    DeleteLevels(correctLevels);
-                    break;
-                default:
-                    return;
-            }
-        }
-
-        private void UpdateLevels(OrderBookLevel[] levels)
+        /// <inheritdoc />
+        protected override void UpdateLevels(IEnumerable<OrderBookLevel> levels)
         {
             foreach (var level in levels)
             {
@@ -525,29 +113,7 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
                     continue;
                 }
 
-                var amountDiff = (level.Amount ?? existing.Amount ?? 0) - (existing.Amount ?? 0);
-                var countDiff = (level.Count ?? existing.Count ?? 0) - (existing.Count ?? 0);
-
-                existing.Price = level.Price ?? existing.Price;
-                existing.Amount = level.Amount ?? existing.Amount;
-                existing.Count = level.Count ?? existing.Count;
-                existing.Pair = level.Pair ?? existing.Pair;
-
-                level.AmountDifference = amountDiff;
-                existing.AmountDifference = amountDiff;
-
-                level.CountDifference = countDiff;
-                existing.CountDifference = countDiff;
-
-                level.AmountDifferenceAggregated += amountDiff;
-                existing.AmountDifferenceAggregated += amountDiff;
-
-                level.CountDifferenceAggregated += countDiff;
-                existing.CountDifferenceAggregated += countDiff;
-
-                level.Amount = level.Amount ?? existing.Amount;
-                level.Count = level.Count ?? existing.Count;
-                level.Price = level.Price ?? existing.Price;
+                ComputeUpdate(existing, level);
 
                 InsertToCollection(collection, existing);
             }
@@ -569,14 +135,8 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
             level.AmountUpdatedCount++;
         }
 
-        private static bool IsInvalidLevel(OrderBookLevel level)
-        {
-            return string.IsNullOrWhiteSpace(level.Id) ||
-                   level.Price == null ||
-                   level.Amount == null;
-        }
-
-        private void DeleteLevels(OrderBookLevel[] levels)
+        /// <inheritdoc />
+        protected override void DeleteLevels(IReadOnlyCollection<OrderBookLevel> levels)
         {
             FillCurrentIndex(levels);
 
@@ -605,301 +165,31 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
                 allLevels.Remove(level.Id);
 
                 if (existing != null)
-                {
-                    var amountDiff = -(existing.Amount ?? 0);
-                    var countDiff = -(existing.Count ?? 0);
-
-                    level.Amount = level.Amount ?? existing.Amount;
-                    level.Count = level.Count ?? existing.Count;
-                    level.Price = level.Price ?? existing.Price;
-
-                    level.AmountDifference = amountDiff;
-                    existing.AmountDifference = amountDiff;
-
-                    level.CountDifference = countDiff;
-                    existing.CountDifference = countDiff;
-
-                    level.AmountDifferenceAggregated += amountDiff;
-                    existing.AmountDifferenceAggregated += amountDiff;
-
-                    level.CountDifferenceAggregated += countDiff;
-                    existing.CountDifferenceAggregated += countDiff;
-                }
+                    ComputeDelete(existing, level);
             }
         }
 
-        private void RecomputeAfterChange()
+        /// <inheritdoc />
+        protected override OrderBookLevel GetFirstBid() => BidLevelsInternal.FirstOrDefault().Value;
+
+        /// <inheritdoc />
+        protected override OrderBookLevel GetFirstAsk() => AskLevelsInternal.FirstOrDefault().Value;
+
+        /// <inheritdoc />
+        protected override OrderBookLevel[] ComputeBidLevels()
         {
-            var firstBid = _bidLevels.FirstOrDefault().Value;
-            var firstAsk = _askLevels.FirstOrDefault().Value;
-
-            BidPrice = firstBid?.Price ?? 0;
-            BidAmount = firstBid?.Amount ?? 0;
-
-            AskPrice = firstAsk?.Price ?? 0;
-            AskAmount = firstAsk?.Amount ?? 0;
-        }
-
-        private void RecomputeAfterChangeAndSetIndexes(List<OrderBookLevel> levels)
-        {
-            RecomputeAfterChange();
-            FillCurrentIndex(levels);
-        }
-
-        private void FillCurrentIndex(List<OrderBookLevel> levels)
-        {
-            if (!IsIndexComputationEnabled)
-                return;
-
-            foreach (var level in levels)
+            lock (Locker)
             {
-                FillIndex(level);
+                return BidLevelsInternal.Values.ToArray();
             }
         }
 
-        private void FillCurrentIndex(OrderBookLevel[] levels)
+        /// <inheritdoc />
+        protected override OrderBookLevel[] ComputeAskLevels()
         {
-            if (!IsIndexComputationEnabled)
-                return;
-
-            foreach (var level in levels)
+            lock (Locker)
             {
-                FillIndex(level);
-            }
-        }
-
-        private void FillIndex(OrderBookLevel level)
-        {
-            if (level.Index.HasValue)
-                return;
-
-            var price = level.Price;
-            if (price == null)
-            {
-                var all = GetAllCollection(level.Side);
-                var existing = all.ContainsKey(level.Id) ? all[level.Id] : null;
-                price = existing?.Price;
-            }
-
-            if (price == null)
-                return;
-
-            var collection = GetLevelsCollection(level.Side);
-            if (collection == null)
-                return;
-
-            var index = collection.IndexOfKey(price.Value);
-            level.Index = index;
-        }
-
-        private OrderBookLevel[] ComputeBidLevels()
-        {
-            return _bidLevels.Values.ToArray();
-        }
-
-        private OrderBookLevel[] ComputeAskLevels()
-        {
-            return _askLevels.Values.ToArray();
-        }
-
-        private OrderBookLevel[] ComputeAllLevels()
-        {
-            lock (_locker)
-            {
-                return _allBidLevels.Concat(_allAskLevels)
-                    .Select(x => x.Value)
-                    .ToArray();
-            }
-        }
-
-        private SortedList<double, OrderBookLevel> GetLevelsCollection(CryptoOrderSide side)
-        {
-            if (side == CryptoOrderSide.Undefined)
-                return null;
-            return side == CryptoOrderSide.Bid ?
-                _bidLevels :
-                _askLevels;
-        }
-
-        private OrderBookLevelsById GetAllCollection(CryptoOrderSide side)
-        {
-            if (side == CryptoOrderSide.Undefined)
-                return null;
-            return side == CryptoOrderSide.Bid ?
-                _allBidLevels :
-                _allAskLevels;
-        }
-
-        private OrderBookChangeInfo NotifyAboutBookChange(List<OrderBookLevel> levels, OrderBookLevelBulk[] sources, bool isSnapshot)
-        {
-            var quotes = new CryptoQuotes(BidPrice, AskPrice, BidAmount, AskAmount);
-            var clonedLevels = DebugEnabled ? levels.Select(x => x.Clone()).ToArray() : new OrderBookLevel[0];
-            var lastSource = sources.LastOrDefault();
-            var change = new OrderBookChangeInfo(
-                TargetPair,
-                TargetPairOriginal,
-                quotes,
-                clonedLevels,
-                sources,
-                isSnapshot
-                )
-            {
-                ExchangeName = lastSource?.ExchangeName,
-                ServerSequence = lastSource?.ServerSequence,
-                ServerTimestamp = lastSource?.ServerTimestamp
-            };
-            return change;
-        }
-
-        private void NotifyIfBidAskChanged(double oldBid, double oldAsk, OrderBookChangeInfo info)
-        {
-            if (PriceChanged(oldBid, oldAsk, info))
-            {
-                _bidAskUpdated.OnNext(info);
-            }
-        }
-
-        private void NotifyIfTopLevelChanged(double oldBid, double oldAsk,
-            double oldBidAmount, double oldAskAmount,
-            OrderBookChangeInfo info)
-        {
-            if (PriceChanged(oldBid, oldAsk, info) || AmountChanged(oldBidAmount, oldAskAmount, info))
-            {
-                _topLevelUpdated.OnNext(info);
-            }
-        }
-
-        private static bool PriceChanged(double oldBid, double oldAsk, OrderBookChangeInfo info)
-        {
-            return !CryptoMathUtils.IsSame(oldBid, info.Quotes.Bid) ||
-                   !CryptoMathUtils.IsSame(oldAsk, info.Quotes.Ask);
-        }
-
-        private static bool AmountChanged(double oldBidAmount, double oldAskAmount, OrderBookChangeInfo info)
-        {
-            return !CryptoMathUtils.IsSame(oldBidAmount, info.Quotes.BidAmount) ||
-                   !CryptoMathUtils.IsSame(oldAskAmount, info.Quotes.AskAmount);
-        }
-
-        private async Task ReloadSnapshotWithCheck()
-        {
-            if (!_source.LoadSnapshotEnabled)
-            {
-                // snapshot loading disabled on the source, do nothing
-                return;
-            }
-
-            await ReloadSnapshot();
-        }
-
-        private async Task ReloadSnapshot()
-        {
-            try
-            {
-                DeactivateAutoSnapshotReloading();
-                DeactivateValidityChecking();
-                await _source.LoadSnapshot(TargetPairOriginal, 10000);
-            }
-            catch (Exception e)
-            {
-                LogAlways(e, $"Failed to reload snapshot for pair '{TargetPair}', " +
-                             $"error: {e.Message}");
-            }
-            finally
-            {
-                RestartAutoSnapshotReloading();
-                RestartValidityChecking();
-            }
-        }
-
-        private async Task CheckValidityAndReload()
-        {
-            var isValid = IsValid();
-            if (isValid)
-            {
-                // ob is valid, just reset counter and do nothing
-                _validityCheckCounter = 0;
-                return;
-            }
-
-            _validityCheckCounter++;
-            if (_validityCheckCounter < ValidityCheckLimit)
-            {
-                // invalid state, but still in the check limit interval
-                // waiting for confirmation
-                return;
-            }
-            _validityCheckCounter = 0;
-
-            LogAlways($"Order book is in invalid state, bid: {BidPrice}, ask: {AskPrice}, " +
-                         "reloading snapshot...");
-            await ReloadSnapshot();
-        }
-
-        private void RestartAutoSnapshotReloading()
-        {
-            DeactivateAutoSnapshotReloading();
-
-            if (!_snapshotReloadEnabled)
-            {
-                // snapshot reloading disabled, do not start timer
-                return;
-            }
-
-            var timerMs = (int)SnapshotReloadTimeout.TotalMilliseconds;
-            _snapshotReloadTimer = new Timer(async _ => await ReloadSnapshotWithCheck(),
-                null, timerMs, timerMs);
-        }
-
-        private void DeactivateAutoSnapshotReloading()
-        {
-            _snapshotReloadTimer?.Dispose();
-            _snapshotReloadTimer = null;
-        }
-
-        private void RestartValidityChecking()
-        {
-            DeactivateValidityChecking();
-
-            if (!_validityCheckEnabled)
-            {
-                // validity checking disabled, do not start timer
-                return;
-            }
-
-            var timerMs = (int)ValidityCheckTimeout.TotalMilliseconds;
-            _validityCheckTimer = new Timer(async _ => await CheckValidityAndReload(),
-                null, timerMs, timerMs);
-        }
-
-        private void DeactivateValidityChecking()
-        {
-            _validityCheckTimer?.Dispose();
-            _validityCheckTimer = null;
-        }
-
-        private void LogDebug(string msg)
-        {
-            if (!DebugLogEnabled)
-                return;
-            LogAlways(msg);
-        }
-
-        private void LogAlways(string msg)
-        {
-            _source.Logger.LogDebug("[ORDER BOOK {exchangeName} {targetPair}] {message}", ExchangeName, TargetPair, msg);
-        }
-
-        private void LogAlways(Exception e, string msg)
-        {
-            _source.Logger.LogDebug(e, "[ORDER BOOK {exchangeName} {targetPair}] {message}", ExchangeName, TargetPair, msg);
-        }
-
-        private class DescendingComparer : IComparer<double>
-        {
-            public int Compare(double x, double y)
-            {
-                return y.CompareTo(x);
+                return AskLevelsInternal.Values.ToArray();
             }
         }
     }

--- a/src/Crypto.Websocket.Extensions.Core/OrderBooks/Models/IOrderBookChangeInfo.cs
+++ b/src/Crypto.Websocket.Extensions.Core/OrderBooks/Models/IOrderBookChangeInfo.cs
@@ -1,4 +1,5 @@
-﻿using Crypto.Websocket.Extensions.Core.Models;
+﻿using System.Collections.Generic;
+using Crypto.Websocket.Extensions.Core.Models;
 
 namespace Crypto.Websocket.Extensions.Core.OrderBooks.Models
 {
@@ -26,12 +27,12 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks.Models
         /// Order book levels that caused the change.
         /// Streamed only when debug mode is enabled. 
         /// </summary>
-        OrderBookLevel[] Levels { get; }
+        IReadOnlyList<OrderBookLevel> Levels { get; }
 
         /// <summary>
         /// Source bulks that caused this update (all levels)
         /// </summary>
-        OrderBookLevelBulk[] Sources { get; }
+        IReadOnlyList<OrderBookLevelBulk> Sources { get; }
 
         /// <summary>
         /// Whenever this order book change update comes from snapshot or diffs

--- a/src/Crypto.Websocket.Extensions.Core/OrderBooks/Models/OrderBookChangeInfo.cs
+++ b/src/Crypto.Websocket.Extensions.Core/OrderBooks/Models/OrderBookChangeInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
 using Crypto.Websocket.Extensions.Core.Models;
 
 namespace Crypto.Websocket.Extensions.Core.OrderBooks.Models
@@ -11,7 +12,7 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks.Models
     {
         /// <inheritdoc />
         public OrderBookChangeInfo(string pair, string pairOriginal,
-            CryptoQuotes quotes, OrderBookLevel[] levels, OrderBookLevelBulk[] sources, 
+            ICryptoQuotes quotes, IReadOnlyList<OrderBookLevel> levels, IReadOnlyList<OrderBookLevelBulk> sources,
             bool isSnapshot)
         {
             Pair = pair;
@@ -41,12 +42,12 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks.Models
         /// Order book levels that caused the change.
         /// Streamed only when debug mode is enabled. 
         /// </summary>
-        public OrderBookLevel[] Levels { get; }
+        public IReadOnlyList<OrderBookLevel> Levels { get; }
 
         /// <summary>
         /// Source bulks that caused this update (all levels)
         /// </summary>
-        public OrderBookLevelBulk[] Sources { get; }
+        public IReadOnlyList<OrderBookLevelBulk> Sources { get; }
 
         /// <summary>
         /// Whenever this order book change update comes from snapshot or diffs

--- a/test/Crypto.Websocket.Extensions.Tests/CryptoOrderBookL2Tests.cs
+++ b/test/Crypto.Websocket.Extensions.Tests/CryptoOrderBookL2Tests.cs
@@ -590,11 +590,11 @@ namespace Crypto.Websocket.Extensions.Tests
             var firstChange = changes.First();
             var secondChange = changes[1];
 
-            Assert.Equal(2, firstChange.Levels.Length);
+            Assert.Equal(2, firstChange.Levels.Count);
             Assert.Equal(499.4, firstChange.Levels.First().Price);
             Assert.Equal(500.2, firstChange.Levels.Last().Price);
 
-            Assert.Equal(6, secondChange.Levels.Length);
+            Assert.Equal(6, secondChange.Levels.Count);
         }
 
         [Fact]

--- a/test/Crypto.Websocket.Extensions.Tests/CryptoOrderBookL3PerformanceTests.cs
+++ b/test/Crypto.Websocket.Extensions.Tests/CryptoOrderBookL3PerformanceTests.cs
@@ -128,7 +128,7 @@ namespace Crypto.Websocket.Extensions.Tests
                 var newAskPrice = maxBidPrice + (i % maxAskPrice);
 
                 // update levels
-                var bulk = GetUpdateBulkL2(
+                var bulk = GetUpdateBulk(CryptoOrderBookType.L3,
                     CreateLevel(pair, newBidPrice, CryptoOrderSide.Bid, bid.Id),
                     CreateLevel(pair, newAskPrice, CryptoOrderSide.Ask, ask.Id)
                 );

--- a/test/Crypto.Websocket.Extensions.Tests/CryptoOrderBookTests.cs
+++ b/test/Crypto.Websocket.Extensions.Tests/CryptoOrderBookTests.cs
@@ -590,11 +590,11 @@ namespace Crypto.Websocket.Extensions.Tests
             var firstChange = changes.First();
             var secondChange = changes[1];
 
-            Assert.Equal(2, firstChange.Levels.Length);
+            Assert.Equal(2, firstChange.Levels.Count);
             Assert.Equal(499.4, firstChange.Levels.First().Price);
             Assert.Equal(500.2, firstChange.Levels.Last().Price);
 
-            Assert.Equal(6, secondChange.Levels.Length);
+            Assert.Equal(6, secondChange.Levels.Count);
         }
 
         [Fact]

--- a/test_integration/Crypto.Websocket.Extensions.Sample/OrderBookExample.cs
+++ b/test_integration/Crypto.Websocket.Extensions.Sample/OrderBookExample.cs
@@ -103,7 +103,7 @@ namespace Crypto.Websocket.Extensions.Sample
                     }
 
                     var metaString = simple ? string.Empty : $" (" +
-                                   $"{x.Sources.Length} " +
+                                   $"{x.Sources.Count} " +
                                    $"{x.Sources.Sum(y => y.Levels.Length)}" +
                                    $"{time})";
                     return


### PR DESCRIPTION
* Fix bug in CryptoOrderBookL3PerformanceTests and tweak test parameters
* Don't dispose the given IOrderBookSource

As requested by @Marfusios I am submitting smaller incremental pull requests to replace the big one I created earlier: #11 

This is the first of them, and the changes here are a prerequisite for further changes that will come in future pull requests.