### PR TITLE
Add support for streaming orderbook changes only when the top N asks or bids changed

### DIFF
--- a/Crypto.Websocket.Extensions.sln.DotSettings
+++ b/Crypto.Websocket.Extensions.sln.DotSettings
@@ -1,5 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=StaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=c873eafb_002Dd57f_002D481d_002D8c93_002D77f6863c2f88/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Static" AccessRightKinds="Protected, ProtectedInternal, Internal, Public, PrivateProtected" Description="Static readonly fields (not private)"&gt;&lt;ElementKinds&gt;&lt;Kind Name="READONLY_FIELD" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EPredefinedNamingRulesToUserRulesUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=aggreg/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=aggtrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Binance/@EntryIndexedValue">True</s:Boolean>

--- a/src/Crypto.Websocket.Extensions.Core/Models/CryptoQuotes.cs
+++ b/src/Crypto.Websocket.Extensions.Core/Models/CryptoQuotes.cs
@@ -23,27 +23,27 @@ namespace Crypto.Websocket.Extensions.Core.Models
         /// <summary>
         /// Top level bid price
         /// </summary>
-        public double Bid { get; internal set; }
+        public double Bid { get; protected set; }
 
         /// <summary>
         /// Top level ask price
         /// </summary>
-        public double Ask { get; internal set; }
+        public double Ask { get; protected set; }
 
         /// <summary>
         /// Current mid price
         /// </summary>
-        public double Mid { get; internal set; }
+        public double Mid { get; protected set; }
 
         /// <summary>
         /// Top level bid amount
         /// </summary>
-        public double BidAmount { get; internal set; }
+        public double BidAmount { get; protected set; }
 
         /// <summary>
         /// Top level ask amount
         /// </summary>
-        public double AskAmount { get; internal set; }
+        public double AskAmount { get; protected set; }
 
         /// <summary>
         /// Returns true if quotes are in valid state

--- a/src/Crypto.Websocket.Extensions.Core/OrderBooks/CryptoOrderBookBase.cs
+++ b/src/Crypto.Websocket.Extensions.Core/OrderBooks/CryptoOrderBookBase.cs
@@ -56,6 +56,11 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
         protected readonly Subject<OrderBookChangeInfo> OrderBookUpdated = new();
 
         /// <summary>
+        /// Subject for streaming events when the top N bid or ask prices or amounts change.
+        /// </summary>
+        protected readonly Subject<TopNLevelsChangeInfo> TopNLevelsUpdated = new();
+
+        /// <summary>
         /// All the bid levels (not grouped by price).
         /// </summary>
         protected readonly OrderBookLevelsById AllBidLevels = new(500);
@@ -77,9 +82,10 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
 
         IDisposable? _subscriptionDiff;
         IDisposable? _subscriptionSnapshot;
+        int _notifyForLevelAndAbove;
 
-        CryptoQuotes _previous;
-        CryptoQuotes _current;
+        L2Snapshot _previous;
+        L2Snapshot _current;
 
         /// <summary>
         /// Cryptocurrency order book.
@@ -92,8 +98,8 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
             CryptoValidations.ValidateInput(targetPair, nameof(targetPair));
             CryptoValidations.ValidateInput(source, nameof(source));
 
-            _previous = new CryptoQuotes(BidPrice, AskPrice, BidAmount, AskAmount);
-            _current = new CryptoQuotes(BidPrice, AskPrice, BidAmount, AskAmount);
+            _previous = new L2Snapshot(this, Array.Empty<CryptoQuote>(), Array.Empty<CryptoQuote>());
+            _current = new L2Snapshot(this, Array.Empty<CryptoQuote>(), Array.Empty<CryptoQuote>());
 
             TargetPairOriginal = targetPair;
             TargetPair = CryptoPairsHelper.Clean(targetPair);
@@ -206,6 +212,29 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
 
         /// <inheritdoc />
         public IObservable<IOrderBookChangeInfo> OrderBookUpdatedStream => OrderBookUpdated.AsObservable();
+
+        /// <inheritdoc />
+        public IObservable<ITopNLevelsChangeInfo> TopNLevelsUpdatedStream => TopNLevelsUpdated.AsObservable();
+
+        /// <inheritdoc />
+        public int NotifyForLevelAndAbove
+        {
+            get => _notifyForLevelAndAbove;
+            set
+            {
+                lock (Locker)
+                {
+                    _notifyForLevelAndAbove = value;
+                    _previous = new L2Snapshot(this, BlankQuotes(), BlankQuotes());
+                    _current = new L2Snapshot(this, BlankQuotes(), BlankQuotes());
+                }
+
+                IReadOnlyList<CryptoQuote> BlankQuotes() => Enumerable
+                    .Range(0, _notifyForLevelAndAbove)
+                    .Select(_ => new CryptoQuote(0, 0))
+                    .ToList();
+            }
+        }
 
         /// <inheritdoc />
         public OrderBookLevel[] BidLevels => ComputeBidLevels();
@@ -336,15 +365,15 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
             }
         }
 
-        void NotifyOrderBookChanges(OrderBookChangeInfo info)
+        void NotifyOrderBookChanges(TopNLevelsChangeInfo levelsChange)
         {
-            OrderBookUpdated.OnNext(info);
+            OrderBookUpdated.OnNext(levelsChange);
 
             (_previous, _current) = (_current, _previous);
 
-            var bidAskChanged = NotifyIfBidAskChanged(info);
-            NotifyIfTopLevelChanged(bidAskChanged, info);
-            UpdateSnapshot(_current);
+            var bidAskChanged = NotifyIfBidAskChanged(levelsChange);
+            var topLevelChanged = NotifyIfTopLevelChanged(bidAskChanged, levelsChange);
+            NotifyIfTopNLevelsChanged(topLevelChanged, levelsChange);
         }
 
         void HandleSnapshot(List<OrderBookLevel> levels)
@@ -382,13 +411,11 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
             _isSnapshotLoaded = true;
         }
 
-        void UpdateSnapshot(CryptoQuotes snapshot)
-        {
-            snapshot.Bid = BidPrice;
-            snapshot.Ask = AskPrice;
-            snapshot.BidAmount = BidAmount;
-            snapshot.AskAmount = AskAmount;
-        }
+        /// <summary>
+        /// Update the given snapshot.
+        /// </summary>
+        /// <param name="snapshot">The snapshot to update.</param>
+        protected abstract void UpdateSnapshot(L2Snapshot snapshot);
 
         /// <summary>
         /// Clears all internal levels state. Called at the beginning of handling a snapshot.
@@ -631,12 +658,12 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
                 : AllAskLevels;
         }
 
-        OrderBookChangeInfo CreateBookChangeNotification(IEnumerable<OrderBookLevel> levels, IReadOnlyList<OrderBookLevelBulk> sources, bool isSnapshot)
+        TopNLevelsChangeInfo CreateBookChangeNotification(IEnumerable<OrderBookLevel> levels, IReadOnlyList<OrderBookLevelBulk> sources, bool isSnapshot)
         {
             var quotes = new CryptoQuotes(BidPrice, AskPrice, BidAmount, AskAmount);
             var clonedLevels = DebugEnabled ? levels.Select(x => x.Clone()).ToArray() : Array.Empty<OrderBookLevel>();
             var lastSource = sources.LastOrDefault();
-            var change = new OrderBookChangeInfo(TargetPair, TargetPairOriginal, quotes, clonedLevels, sources, isSnapshot)
+            var change = new TopNLevelsChangeInfo(TargetPair, TargetPairOriginal, quotes, clonedLevels, sources, isSnapshot)
             {
                 ExchangeName = lastSource?.ExchangeName,
                 ServerSequence = lastSource?.ServerSequence,
@@ -666,6 +693,41 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
                 return true;
             }
             return false;
+        }
+
+        bool NotifyIfTopNLevelsChanged(bool topLevelChanged, TopNLevelsChangeInfo info)
+        {
+            UpdateSnapshot(_current);
+
+            if (topLevelChanged ||
+                HasChange(_previous.Bids, _current.Bids) ||
+                HasChange(_previous.Asks, _current.Asks))
+            {
+                info.Snapshot = new L2Snapshot(this,
+                    _current.Bids.Where(x => x.IsValid).ToList(),
+                    _current.Asks.Where(x => x.IsValid).ToList());
+
+                TopNLevelsUpdated.OnNext(info);
+                return true;
+            }
+            return false;
+
+            static bool HasChange(IReadOnlyList<CryptoQuote> left, IReadOnlyList<CryptoQuote> right)
+            {
+                if (left.Count != right.Count)
+                    return true;
+
+                foreach (var index in Enumerable.Range(0, left.Count))
+                {
+                    var leftQuote = left[index];
+                    var rightQuote = right[index];
+
+                    if (!CryptoMathUtils.IsSame(leftQuote.Price, rightQuote.Price) ||
+                        !CryptoMathUtils.IsSame(leftQuote.Amount, rightQuote.Amount))
+                        return true;
+                }
+                return false;
+            }
         }
 
         async Task ReloadSnapshotWithCheck()

--- a/src/Crypto.Websocket.Extensions.Core/OrderBooks/CryptoQuote.cs
+++ b/src/Crypto.Websocket.Extensions.Core/OrderBooks/CryptoQuote.cs
@@ -1,0 +1,31 @@
+﻿namespace Crypto.Websocket.Extensions.Core.OrderBooks
+{
+    /// <summary>
+    /// A price and amount.
+    /// </summary>
+    public class CryptoQuote
+    {
+        /// <summary>
+        /// Creates a new quote.
+        /// </summary>
+        /// <param name="price">The price.</param>
+        /// <param name="amount">The amount.</param>
+        public CryptoQuote(double price, double amount)
+        {
+            Price = price;
+            Amount = amount;
+        }
+
+        /// <summary>
+        /// The price.
+        /// </summary>
+        public double Price { get; set; }
+
+        /// <summary>
+        /// The amount.
+        /// </summary>
+        public double Amount { get; set; }
+
+        internal bool IsValid => Price != 0 && Amount != 0;
+    }
+}

--- a/src/Crypto.Websocket.Extensions.Core/OrderBooks/ICryptoOrderBook.cs
+++ b/src/Crypto.Websocket.Extensions.Core/OrderBooks/ICryptoOrderBook.cs
@@ -105,6 +105,16 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
         IObservable<IOrderBookChangeInfo> OrderBookUpdatedStream { get; }
 
         /// <summary>
+        /// Streams data on subset of order book changes (price or amount within top N price levels, specified by <see cref="NotifyForLevelAndAbove"/>)
+        /// </summary>
+        IObservable<ITopNLevelsChangeInfo> TopNLevelsUpdatedStream { get; }
+
+        /// <summary>
+        /// Specifies how many levels to check for streaming updates
+        /// </summary>
+        int NotifyForLevelAndAbove { get; set; }
+
+        /// <summary>
         /// Current bid side of the order book (ordered from higher to lower price)
         /// </summary>
         OrderBookLevel[] BidLevels { get; }

--- a/src/Crypto.Websocket.Extensions.Core/OrderBooks/L2Snapshot.cs
+++ b/src/Crypto.Websocket.Extensions.Core/OrderBooks/L2Snapshot.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using Crypto.Websocket.Extensions.Core.Models;
+
+namespace Crypto.Websocket.Extensions.Core.OrderBooks
+{
+    /// <summary>
+    /// A snapshot of bid and ask levels.
+    /// </summary>
+    public class L2Snapshot : CryptoQuotes
+    {
+        /// <summary>
+        /// Creates a new snapshot.
+        /// </summary>
+        /// <param name="cryptoOrderBook">The source.</param>
+        /// <param name="bids">The bids.</param>
+        /// <param name="asks">The asks.</param>
+        public L2Snapshot(ICryptoOrderBook cryptoOrderBook, IReadOnlyList<CryptoQuote> bids, IReadOnlyList<CryptoQuote> asks)
+            : base(cryptoOrderBook.BidPrice, cryptoOrderBook.AskPrice, cryptoOrderBook.BidAmount, cryptoOrderBook.AskAmount)
+        {
+            Bids = bids;
+            Asks = asks;
+        }
+
+        /// <summary>
+        /// Updates the snapshot.
+        /// </summary>
+        /// <param name="bid">The bid price.</param>
+        /// <param name="ask">The ask price.</param>
+        /// <param name="bidAmount">The bid amount.</param>
+        /// <param name="askAmount">The ask amount.</param>
+        internal void Update(double bid, double ask, double bidAmount, double askAmount)
+        {
+            Bid = bid;
+            Ask = ask;
+            BidAmount = bidAmount;
+            AskAmount = askAmount;
+            Mid = (bid + ask) / 2;
+        }
+
+        /// <summary>
+        /// Bid levels.
+        /// </summary>
+        public IReadOnlyList<CryptoQuote> Bids { get; }
+
+        /// <summary>
+        /// Ask levels.
+        /// </summary>
+        public IReadOnlyList<CryptoQuote> Asks { get; }
+    }
+}

--- a/src/Crypto.Websocket.Extensions.Core/OrderBooks/Models/ITopNLevelsChangeInfo.cs
+++ b/src/Crypto.Websocket.Extensions.Core/OrderBooks/Models/ITopNLevelsChangeInfo.cs
@@ -1,0 +1,10 @@
+﻿namespace Crypto.Websocket.Extensions.Core.OrderBooks.Models;
+
+/// <inheritdoc />
+public interface ITopNLevelsChangeInfo : IOrderBookChangeInfo
+{
+    /// <summary>
+    /// A snapshot of the the orderbook.
+    /// </summary>
+    L2Snapshot Snapshot { get; }
+}

--- a/src/Crypto.Websocket.Extensions.Core/OrderBooks/Models/TopNLevelsChangeInfo.cs
+++ b/src/Crypto.Websocket.Extensions.Core/OrderBooks/Models/TopNLevelsChangeInfo.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using Crypto.Websocket.Extensions.Core.Models;
+
+namespace Crypto.Websocket.Extensions.Core.OrderBooks.Models;
+
+/// <summary>
+/// Info about changed order book
+/// </summary>
+public class TopNLevelsChangeInfo : OrderBookChangeInfo, ITopNLevelsChangeInfo
+{
+    /// <inheritdoc />
+    public TopNLevelsChangeInfo(string pair, string pairOriginal,
+        ICryptoQuotes quotes, IReadOnlyList<OrderBookLevel> levels, IReadOnlyList<OrderBookLevelBulk> sources,
+        bool isSnapshot)
+        : base(pair, pairOriginal, quotes, levels, sources, isSnapshot)
+    {
+    }
+
+    /// <summary>
+    /// The L2 snapshot of the top N bid/ask levels
+    /// </summary>
+    public L2Snapshot Snapshot { get; internal set; }
+}

--- a/test/Crypto.Websocket.Extensions.Tests/CryptoOrderBookL2PerformanceTests.cs
+++ b/test/Crypto.Websocket.Extensions.Tests/CryptoOrderBookL2PerformanceTests.cs
@@ -38,7 +38,10 @@ namespace Crypto.Websocket.Extensions.Tests
             var data = GetOrderBookSnapshotMockData(pair, 500);
             var snapshot = new OrderBookLevelBulk(OrderBookAction.Insert, data, CryptoOrderBookType.L2);
             var source = new OrderBookSourceMock(snapshot);
-            var orderBook = new CryptoOrderBookL2(pair, source);
+            var orderBook = new CryptoOrderBookL2(pair, source)
+            {
+                NotifyForLevelAndAbove = 300
+            };
 
             source.BufferEnabled = false;
             source.LoadSnapshotEnabled = false;
@@ -69,7 +72,10 @@ namespace Crypto.Websocket.Extensions.Tests
             var data = GetOrderBookSnapshotMockData(pair, 500);
             var snapshot = new OrderBookLevelBulk(OrderBookAction.Insert, data, CryptoOrderBookType.L2);
             var source = new OrderBookSourceMock(snapshot);
-            var orderBook = new CryptoOrderBookL2(pair, source);
+            var orderBook = new CryptoOrderBookL2(pair, source)
+            {
+                NotifyForLevelAndAbove = 300
+            };
 
             source.BufferEnabled = false;
             source.LoadSnapshotEnabled = false;
@@ -100,7 +106,10 @@ namespace Crypto.Websocket.Extensions.Tests
             var data = GetOrderBookSnapshotMockData(pair, 500);
             var snapshot = new OrderBookLevelBulk(OrderBookAction.Insert, data, CryptoOrderBookType.L2);
             var source = new OrderBookSourceMock(snapshot);
-            var orderBook = new CryptoOrderBookL2(pair, source);
+            var orderBook = new CryptoOrderBookL2(pair, source)
+            {
+                NotifyForLevelAndAbove = 300
+            };
 
             source.BufferEnabled = false;
             source.LoadSnapshotEnabled = false;
@@ -131,7 +140,10 @@ namespace Crypto.Websocket.Extensions.Tests
             var data = GetOrderBookSnapshotMockData(pair, 500);
             var snapshot = new OrderBookLevelBulk(OrderBookAction.Insert, data, CryptoOrderBookType.L2);
             var source = new OrderBookSourceMock(snapshot);
-            var orderBook = new CryptoOrderBookL2(pair, source);
+            var orderBook = new CryptoOrderBookL2(pair, source)
+            {
+                NotifyForLevelAndAbove = 30
+            };
 
             source.BufferEnabled = false;
             source.LoadSnapshotEnabled = false;
@@ -154,7 +166,10 @@ namespace Crypto.Websocket.Extensions.Tests
             var data = GetOrderBookSnapshotMockData(pair, 500);
             var snapshot = new OrderBookLevelBulk(OrderBookAction.Insert, data, CryptoOrderBookType.L2);
             var source = new OrderBookSourceMock(snapshot);
-            var orderBook = new CryptoOrderBookL2(pair, source);
+            var orderBook = new CryptoOrderBookL2(pair, source)
+            {
+                NotifyForLevelAndAbove = 300
+            };
             var endTime = DateTime.MinValue;
 
             orderBook.OrderBookUpdatedStream.Subscribe(x => endTime = DateTime.UtcNow);

--- a/test/Crypto.Websocket.Extensions.Tests/CryptoOrderBookL3PerformanceTests.cs
+++ b/test/Crypto.Websocket.Extensions.Tests/CryptoOrderBookL3PerformanceTests.cs
@@ -31,7 +31,10 @@ namespace Crypto.Websocket.Extensions.Tests
             var snapshot = new OrderBookLevelBulk(OrderBookAction.Insert, data, CryptoOrderBookType.L3);
             var source = new OrderBookSourceMock(snapshot);
 
-            ICryptoOrderBook orderBook = new CryptoOrderBook(pair, source, CryptoOrderBookType.L3);
+            ICryptoOrderBook orderBook = new CryptoOrderBook(pair, source, CryptoOrderBookType.L3)
+            {
+                NotifyForLevelAndAbove = 30
+            };
 
             source.BufferEnabled = false;
             source.LoadSnapshotEnabled = false;
@@ -54,7 +57,10 @@ namespace Crypto.Websocket.Extensions.Tests
             var snapshot = new OrderBookLevelBulk(OrderBookAction.Insert, data, CryptoOrderBookType.L3);
             var source = new OrderBookSourceMock(snapshot);
 
-            ICryptoOrderBook orderBook = new CryptoOrderBook(pair, source, CryptoOrderBookType.L3);
+            ICryptoOrderBook orderBook = new CryptoOrderBook(pair, source, CryptoOrderBookType.L3)
+            {
+                NotifyForLevelAndAbove = 10
+            };
 
             source.BufferEnabled = false;
             source.LoadSnapshotEnabled = false;
@@ -77,7 +83,10 @@ namespace Crypto.Websocket.Extensions.Tests
             var snapshot = new OrderBookLevelBulk(OrderBookAction.Insert, data, CryptoOrderBookType.L3);
             var source = new OrderBookSourceMock(snapshot);
 
-            ICryptoOrderBook orderBook = new CryptoOrderBook(pair, source, CryptoOrderBookType.L3);
+            ICryptoOrderBook orderBook = new CryptoOrderBook(pair, source, CryptoOrderBookType.L3)
+            {
+                NotifyForLevelAndAbove = 3
+            };
 
             source.BufferEnabled = false;
             source.LoadSnapshotEnabled = false;

--- a/test_integration/Crypto.Websocket.Extensions.Sample/OrderBookExample.cs
+++ b/test_integration/Crypto.Websocket.Extensions.Sample/OrderBookExample.cs
@@ -47,6 +47,13 @@ namespace Crypto.Websocket.Extensions.Sample
             var bitstampOb = await StartBitstamp("BTCUSD", optimized, l2OrderBook);
             //var huobiOb = await StartHuobi("btcusdt", optimized, l2OrderBook);
 
+            const int topLevels = 10;
+
+            bitmexOb.NotifyForLevelAndAbove = topLevels;
+            bitfinexOb.NotifyForLevelAndAbove = topLevels;
+            binanceOb.NotifyForLevelAndAbove = topLevels;
+            bitstampOb.NotifyForLevelAndAbove = topLevels;
+
             Log.Information("Waiting for price change...");
 
             Observable.CombineLatest(new[]

--- a/test_integration/Crypto.Websocket.Extensions.Sample/OrderBookL3Example.cs
+++ b/test_integration/Crypto.Websocket.Extensions.Sample/OrderBookL3Example.cs
@@ -24,12 +24,14 @@ namespace Crypto.Websocket.Extensions.Sample
 
             //var ob = await StartBitfinex("BTCUSD", optimized);
             var ob = await StartBitfinex("btcf0:ustf0", optimized);
+			ob.NotifyForLevelAndAbove = 30;
 
             Log.Information("Waiting for price change...");
 
             Observable.CombineLatest(new[]
                 {
-                    ob.OrderBookUpdatedStream
+                    //ob.OrderBookUpdatedStream
+                    ob.TopNLevelsUpdatedStream
                 })
                 .Subscribe(x => HandleQuoteChanged(ob, levelsCount));
         }


### PR DESCRIPTION
The reason for adding this support is so that a trading bot doesn't need to process orderbook updates that are happening "deep down" in the orderbook. This is because many trading algorithms are only concerned with orderbooks changes that would materially impact it's trading activity.

Most of the time we are only interested in the top few levels of asks/bids as we would be able to fill our market orders without causing much slippage. The intention behind this change is to optimize the resource usage of consuming code so that they don't need to process "frivolous" orderbook updates.