### PR TITLE
Add tests to cover the filtering behaviour when stream updates are only pushed if there is a change in the top N levels

### DIFF
--- a/src/Crypto.Websocket.Extensions.Core/OrderBooks/CryptoOrderBookBase.cs
+++ b/src/Crypto.Websocket.Extensions.Core/OrderBooks/CryptoOrderBookBase.cs
@@ -232,7 +232,7 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
                 IReadOnlyList<CryptoQuote> BlankQuotes() => Enumerable
                     .Range(0, _notifyForLevelAndAbove)
                     .Select(_ => new CryptoQuote(0, 0))
-                    .ToList();
+                    .ToList(_notifyForLevelAndAbove);
             }
         }
 
@@ -710,8 +710,8 @@ namespace Crypto.Websocket.Extensions.Core.OrderBooks
                 HasChange(_previous.Asks, _current.Asks))
             {
                 info.Snapshot = new L2Snapshot(this,
-                    _current.Bids.Where(x => x.IsValid).ToList(),
-                    _current.Asks.Where(x => x.IsValid).ToList());
+                    _current.Bids.Where(x => x.IsValid).ToList(_current.Bids.Count),
+                    _current.Asks.Where(x => x.IsValid).ToList(_current.Asks.Count));
 
                 TopNLevelsUpdated.OnNext(info);
                 return true;

--- a/src/Crypto.Websocket.Extensions.Core/OrderBooks/EnumerableExtensions.cs
+++ b/src/Crypto.Websocket.Extensions.Core/OrderBooks/EnumerableExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Crypto.Websocket.Extensions.Core.OrderBooks
+{
+    internal static class EnumerableExtensions
+    {
+        public static List<T> ToList<T>(this IEnumerable<T> items, int length)
+        {
+            var list = new List<T>(length);
+            list.AddRange(items.Take(length));
+            return list;
+        }
+    }
+}

--- a/src/Crypto.Websocket.Extensions.Core/OrderBooks/Models/ITopNLevelsChangeInfo.cs
+++ b/src/Crypto.Websocket.Extensions.Core/OrderBooks/Models/ITopNLevelsChangeInfo.cs
@@ -4,7 +4,7 @@
 public interface ITopNLevelsChangeInfo : IOrderBookChangeInfo
 {
     /// <summary>
-    /// A snapshot of the the orderbook.
+    /// A snapshot of the orderbook.
     /// </summary>
     L2Snapshot Snapshot { get; }
 }

--- a/src/Crypto.Websocket.Extensions/OrderBooks/Sources/BitfinexOrderBookSource.cs
+++ b/src/Crypto.Websocket.Extensions/OrderBooks/Sources/BitfinexOrderBookSource.cs
@@ -108,7 +108,7 @@ namespace Crypto.Websocket.Extensions.OrderBooks.Sources
         }
 
         /// <inheritdoc />
-        protected override async Task<OrderBookLevelBulk?> LoadSnapshotInternal(string? pair, int count)
+        protected override async Task<OrderBookLevelBulk?> LoadSnapshotInternal(string? pair, int count = 1000)
         {
             Book[]? parsed = null;
             var pairSafe = (pair ?? string.Empty).Trim().ToUpper();


### PR DESCRIPTION
Also includes a few other minor updates:

- Specify generic list capacity to reduce allocations from resizing
- Ensure that `LoadSnapshotInternal` method overload for BitfinexOrderBookSource also makes count parameter optional, like others
- Fix typo
- Ensure that any exceptions inside `ProcessData` method of `OrderBookSourceBase` are caught and logged, so that we continue processing after transient failures in downstream code